### PR TITLE
調整導覽列並強化手機選單毛玻璃效果

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -32,7 +32,8 @@ export default function Navbar() {
         { label: '加入我們', id: 'join' },
     ];
 
-    const navClasses = `fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${isScrolled || isMobileMenuOpen
+    // 僅針對顏色變化做轉場，避免滾動時位置產生位移
+    const navClasses = `fixed top-0 left-0 right-0 z-50 transition-colors duration-300 ${isScrolled || isMobileMenuOpen
             ? 'bg-surface/90 backdrop-blur-xl border-b border-border shadow-lg'
             : 'bg-transparent border-b border-transparent'
         }`;
@@ -105,13 +106,14 @@ export default function Navbar() {
             {isMobileMenuOpen && (
                 // 背景遮罩，附帶毛玻璃效果，點擊可關閉選單
                 <div
-                    className="md:hidden fixed inset-0 bg-background/30 backdrop-blur-md z-40"
+                    // 強化背景模糊與遮罩透明度，使下拉選單內容更清晰
+                    className="md:hidden fixed inset-0 bg-background/50 backdrop-blur-xl z-40"
                     onClick={() => setIsMobileMenuOpen(false)}
                 ></div>
             )}
             {/* 毛玻璃選單容器 */}
             <div
-                className={`md:hidden absolute top-full left-0 w-full bg-surface/60 backdrop-blur-lg transition-all duration-300 ease-in-out overflow-hidden z-50 ${isMobileMenuOpen ? 'max-h-screen border-t border-border' : 'max-h-0'
+                className={`md:hidden absolute top-full left-0 w-full bg-surface/70 backdrop-blur-xl transition-[max-height] duration-300 ease-in-out overflow-hidden z-50 ${isMobileMenuOpen ? 'max-h-screen border-t border-border' : 'max-h-0'
                     }`}
             >
                 <div className="p-4 space-y-4">


### PR DESCRIPTION
## 摘要
- 強化手機下拉選單與背景遮罩的毛玻璃效果，提升可讀性
- 導覽列僅針對顏色轉場，避免滾動時位置位移

## 測試
- `npm test`（缺少 script）
- `npm run build`（缺少網路字型導致編譯失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b292c0c7988323a444c41d408cdf97