### PR TITLE
fix: ensure mobile menu backdrop blur

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -45,89 +45,92 @@ export default function Navbar() {
     const themeSwitcherColor = isScrolled || isMobileMenuOpen ? 'text-heading hover:text-brand' : 'text-white hover:text-gray-200 drop-shadow-md';
 
     return (
-        <nav className={navClasses}>
-            <div className="max-w-7xl mx-auto px-6 lg:px-8">
-                <div className="flex items-center justify-between h-16 md:h-24">
-                    {/* 標誌區塊 */}
-                    <div className="flex-shrink-0">
-                        <a href="#" className="flex items-center space-x-2 md:space-x-3" aria-label="Homepage">
-                            <div className="w-10 h-10 md:w-16 md:h-16 flex items-center justify-center">
-                                <Image
-                                    src={bracketsGif}
-                                    alt="GDG Logo"
-                                    width={64}
-                                    height={64}
-                                    className="w-full h-full object-contain"
-                                />
-                            </div>
-                            <div className={`transition-colors duration-300 ${logoColor}`}>
-                                <div className="phone-liner-bold md:pc-liner-bold">Google Developer Groups</div>
-                                <div className="text-xs md:text-sm font-light opacity-80">on Campus NCUE</div>
-                            </div>
-                        </a>
-                    </div>
+        <>
+            {/* 導覽列本體 */}
+            <nav className={navClasses}>
+                <div className="max-w-7xl mx-auto px-6 lg:px-8">
+                    <div className="flex items-center justify-between h-16 md:h-24">
+                        {/* 標誌區塊 */}
+                        <div className="flex-shrink-0">
+                            <a href="#" className="flex items-center space-x-2 md:space-x-3" aria-label="Homepage">
+                                <div className="w-10 h-10 md:w-16 md:h-16 flex items-center justify-center">
+                                    <Image
+                                        src={bracketsGif}
+                                        alt="GDG Logo"
+                                        width={64}
+                                        height={64}
+                                        className="w-full h-full object-contain"
+                                    />
+                                </div>
+                                <div className={`transition-colors duration-300 ${logoColor}`}>
+                                    <div className="phone-liner-bold md:pc-liner-bold">Google Developer Groups</div>
+                                    <div className="text-xs md:text-sm font-light opacity-80">on Campus NCUE</div>
+                                </div>
+                            </a>
+                        </div>
 
-                    {/* 桌面版選單 */}
-                    <div className="hidden md:flex items-center space-x-8">
+                        {/* 桌面版選單 */}
+                        <div className="hidden md:flex items-center space-x-8">
+                            {navLinks.map(({ label, id }) => (
+                                <button
+                                    key={id}
+                                    onClick={() => scrollToSection(id)}
+                                    className={`pc-liner-bold transition-all duration-300 relative group ${linkColor}`}
+                                >
+                                    {label}
+                                    <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-brand transition-all duration-300 group-hover:w-full"></span>
+                                </button>
+                            ))}
+                            <ThemeSwitcher colorClass={themeSwitcherColor} />
+                        </div>
+
+                        {/* 手機版漢堡選單按鈕 */}
+                        <div className="md:hidden flex items-center">
+                            <ThemeSwitcher colorClass={themeSwitcherColor} />
+                            <button
+                                onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                                className={`p-2 ml-2 transition-colors duration-300 ${mobileIconColor}`}
+                                aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
+                                aria-expanded={isMobileMenuOpen}
+                            >
+                                {isMobileMenuOpen ? (
+                                    // 開啟時顯示關閉 icon
+                                    <XMarkIcon className="w-6 h-6" />
+                                ) : (
+                                    // 關閉時顯示漢堡 icon
+                                    <Bars3Icon className="w-6 h-6" />
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                {/* 毛玻璃選單容器 */}
+                <div
+                    className={`md:hidden absolute top-full left-0 w-full bg-surface/80 backdrop-blur-lg transition-[max-height] duration-300 ease-in-out overflow-hidden z-50 ${isMobileMenuOpen ? 'max-h-screen border-t border-border shadow-lg' : 'max-h-0'
+                        }`}
+                >
+                    <div className="p-4 space-y-4">
                         {navLinks.map(({ label, id }) => (
                             <button
                                 key={id}
                                 onClick={() => scrollToSection(id)}
-                                className={`pc-liner-bold transition-all duration-300 relative group ${linkColor}`}
+                                className="block w-full text-left phone-liner-bold text-heading hover:text-brand transition-colors duration-200 py-2"
                             >
                                 {label}
-                                <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-brand transition-all duration-300 group-hover:w-full"></span>
                             </button>
                         ))}
-                        <ThemeSwitcher colorClass={themeSwitcherColor} />
-                    </div>
-
-                    {/* 手機版漢堡選單按鈕 */}
-                    <div className="md:hidden flex items-center">
-                        <ThemeSwitcher colorClass={themeSwitcherColor} />
-                        <button
-                            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-                            className={`p-2 ml-2 transition-colors duration-300 ${mobileIconColor}`}
-                            aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
-                            aria-expanded={isMobileMenuOpen}
-                        >
-                            {isMobileMenuOpen ? (
-                                // 開啟時顯示關閉 icon
-                                <XMarkIcon className="w-6 h-6" />
-                            ) : (
-                                // 關閉時顯示漢堡 icon
-                                <Bars3Icon className="w-6 h-6" />
-                            )}
-                        </button>
                     </div>
                 </div>
-            </div>
-            {/* 手機版下拉選單與模糊背景 */}
+            </nav>
+
+            {/* 背景遮罩，移到 nav 之外以確保固定定位相對於視窗 */}
             {isMobileMenuOpen && (
-                // 背景遮罩，附帶毛玻璃效果，點擊可關閉選單
                 <div
-                    // 提高遮罩不透明度與模糊程度，讓選單更易閱讀
                     className="md:hidden fixed inset-0 bg-background/60 backdrop-blur-lg z-40"
                     onClick={() => setIsMobileMenuOpen(false)}
                 ></div>
             )}
-            {/* 毛玻璃選單容器 */}
-            <div
-                className={`md:hidden absolute top-full left-0 w-full bg-surface/80 backdrop-blur-lg transition-[max-height] duration-300 ease-in-out overflow-hidden z-50 ${isMobileMenuOpen ? 'max-h-screen border-t border-border shadow-lg' : 'max-h-0'
-                    }`}
-            >
-                <div className="p-4 space-y-4">
-                    {navLinks.map(({ label, id }) => (
-                        <button
-                            key={id}
-                            onClick={() => scrollToSection(id)}
-                            className="block w-full text-left phone-liner-bold text-heading hover:text-brand transition-colors duration-200 py-2"
-                        >
-                            {label}
-                        </button>
-                    ))}
-                </div>
-            </div>
-        </nav>
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- refactor mobile menu overlay rendering to sit outside `<nav>` so background blur covers the whole viewport

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2962fb2908323b81ffa1a9b62fdef