### PR TITLE
feat: add language switch and English interface

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Source_Sans_3 } from "next/font/google";
 import "./globals.css";
 import ScrollToTop from '@/components/ScrollToTop';
+import { LanguageProvider } from '@/hooks/useLanguage';
 
 const sourceSans = Source_Sans_3({
   variable: "--font-source-sans",
@@ -35,10 +36,12 @@ export default function RootLayout({ children }) {
         />
       </head>
       <body className={`${sourceSans.variable} antialiased`}>
-        <div className="fixed inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
-        <div className="fixed inset-0 -z-20 h-full w-full bg-background [mask-image:radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"></div>
-        {children}
-        <ScrollToTop />
+        <LanguageProvider>
+          <div className="fixed inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+          <div className="fixed inset-0 -z-20 h-full w-full bg-background [mask-image:radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"></div>
+          {children}
+          <ScrollToTop />
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
 import Image from 'next/image';
 import event_img_1 from '@/images/events/1.png';
 import event_img_2 from '@/images/events/2.png';
@@ -14,6 +15,7 @@ export default function Events() {
     const [isVisible, setIsVisible] = useState(false);
     const [currentImage, setCurrentImage] = useState(0);
     const ref = useRef(null);
+    const { language } = useLanguage();
 
     // 活動圖片 - 使用 public 目錄中的圖片
     const eventImages = [
@@ -24,11 +26,17 @@ export default function Events() {
         event_img_5
     ];
 
-    const highlights = [
-        { icon: '🤖', text: 'n8n 工作坊：親手打造自動化 Line Bot' },
-        { icon: '💡', text: '提示工程：從零到一啟動 AI 原力' },
-        { icon: '🔥', text: '社群火花：點燃對技術的熱情與潛能' },
-    ];
+    const highlights = language === 'zh'
+        ? [
+            { icon: '🤖', text: 'n8n 工作坊：親手打造自動化 Line Bot' },
+            { icon: '💡', text: '提示工程：從零到一啟動 AI 原力' },
+            { icon: '🔥', text: '社群火花：點燃對技術的熱情與潛能' },
+        ]
+        : [
+            { icon: '🤖', text: 'n8n workshop: build an automated Line bot' },
+            { icon: '💡', text: 'Prompt engineering: ignite your AI power from zero' },
+            { icon: '🔥', text: 'Community sparks: fuel passion and potential for tech' },
+        ];
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -135,15 +143,18 @@ export default function Events() {
                                     className="w-8 h-8 md:w-10 md:h-10 object-contain"
                                 />
                                 <p className="phone-liner-bold md:pc-liner-bold text-brand">
-                                    回顧我們的「Build with AI 2025」
+                                    {language === 'zh' ? '回顧我們的「Build with AI 2025」' : 'Review of "Build with AI 2025"'}
                                 </p>
                             </div>
                             <h2 className="phone-h1 md:pc-h1 text-heading mb-6 md:mb-8 leading-tight">
-                                不只是一場活動，<br className="hidden md:block" />
-                                而是一場技術革命的開端。
+                                {language === 'zh'
+                                    ? <>不只是一場活動，<br className="hidden md:block" />而是一場技術革命的開端。</>
+                                    : <>More than just an event,<br className="hidden md:block" />it was the start of a tech revolution.</>}
                             </h2>
                             <p className="phone-liner md:pc-liner text-muted mb-8 md:mb-10 leading-relaxed">
-                                我們將 AI 的力量帶入校園，打破技術壁壘，引導每位參與者從零到一啟動自己的 AI 原力。透過無程式碼的 n8n 工作坊，現場夥伴都親手打造出能解決實際問題的自動化 Line 聊天機器人。
+                                {language === 'zh'
+                                    ? '我們將 AI 的力量帶入校園，打破技術壁壘，引導每位參與者從零到一啟動自己的 AI 原力。透過無程式碼的 n8n 工作坊，現場夥伴都親手打造出能解決實際問題的自動化 Line 聊天機器人。'
+                                    : 'We brought the power of AI to campus, breaking technical barriers and guiding every participant to kickstart their AI journey. In the no-code n8n workshop, attendees built automated Line chatbots to solve real problems.'}
                             </p>
                         </div>
 

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
 import Image from 'next/image';
 import assemblyGif from '@/images/stickers/assembly.gif';
 import sliderGif from '@/images/stickers/slider.gif';
@@ -8,6 +9,7 @@ import sliderGif from '@/images/stickers/slider.gif';
 
 export default function Hero() {
     const [isLoaded, setIsLoaded] = useState(false);
+    const { language } = useLanguage();
 
     useEffect(() => {
         setIsLoaded(true);
@@ -144,7 +146,9 @@ export default function Hero() {
                         height={48}
                         className="w-12 h-12 md:w-20 md:h-20 object-contain"
                     />
-                    <span className="text-lg md:text-2xl font-bold text-white">探索我們的故事</span>
+                    <span className="text-lg md:text-2xl font-bold text-white">
+                        {language === 'zh' ? '探索我們的故事' : 'Explore Our Story'}
+                    </span>
                     <svg
                         className="w-5 h-5 md:w-7 md:h-7 group-hover:translate-y-1 transition-transform duration-300 text-white"
                         fill="none"

--- a/src/components/JoinUs.jsx
+++ b/src/components/JoinUs.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { ArrowRightIcon, EnvelopeIcon } from '@heroicons/react/24/solid';
+import { useLanguage } from '@/hooks/useLanguage';
 import gdgLogo from '@/images/icon/brackets.gif';
 import githubIcon from '@/images/icon/github (1).png';
 import instagramIcon from '@/images/icon/instagram.png';
@@ -12,6 +13,7 @@ import lineIcon from '@/images/icon/line.png';
 export default function JoinUs() {
     const [isVisible, setIsVisible] = useState(false);
     const ref = useRef(null);
+    const { language } = useLanguage();
 
     const socialLinks = [
         { name: 'GitHub', icon: githubIcon, url: 'https://github.com/GDG-on-campus-NCUE' },
@@ -73,10 +75,12 @@ export default function JoinUs() {
                         className={`phone-h1 md:pc-h1 mb-6 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
                         style={{ color: colorPalette[colorIndex] }}
                     >
-                        你的程式碼，是校園的下一個未來。
+                        {language === 'zh' ? '你的程式碼，是校園的下一個未來。' : 'Your code is the next future of campus.'}
                     </h2>
                     <p className={`phone-liner md:pc-h3 text-muted max-w-3xl mx-auto mb-10 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`} style={{ transitionDelay: '0.2s' }}>
-                        我們相信，每一行程式碼都蘊含著改變的潛力。無論你的起點在哪，只要你對技術懷抱熱情，渴望將想法付諸實踐，這裡就是你連結同好、共同成長的最佳社群。
+                        {language === 'zh'
+                            ? '我們相信，每一行程式碼都蘊含著改變的潛力。無論你的起點在哪，只要你對技術懷抱熱情，渴望將想法付諸實踐，這裡就是你連結同好、共同成長的最佳社群。'
+                            : 'We believe every line of code carries the power to change. Wherever you start, if you love technology and want to turn ideas into reality, this is the community to connect and grow.'}
                     </p>
 
                     {/* 手機版寬度全滿，桌機保持原樣 */}
@@ -86,7 +90,7 @@ export default function JoinUs() {
                         style={{ transitionDelay: '0.4s' }}
                     >
                         <Image src={lineIcon} alt="Line Icon" width={28} height={28} className="w-6 h-6 md:w-7 md:h-7" />
-                        <span>立即加入 Line 社群</span>
+                        <span>{language === 'zh' ? '立即加入 Line 社群' : 'Join our Line group now'}</span>
                         <ArrowRightIcon className="w-5 h-5 md:w-6 md:h-6" />
                     </button>
                 </div>
@@ -106,14 +110,16 @@ export default function JoinUs() {
                                 <Image src={gdgLogo} alt="GDG on Campus NCUE Logo" width={200} height={40} />
                             </a>
                             <p className="text-muted text-sm max-w-sm">
-                                一個由學生主導、Google 支持的校園技術方舟。我們致力於連結校園與真實世界，透過實戰專案、前沿分享與社群協作，賦能每一位懷抱理想的開發者。
+                                {language === 'zh'
+                                    ? '一個由學生主導、Google 支持的校園技術方舟。我們致力於連結校園與真實世界，透過實戰專案、前沿分享與社群協作，賦能每一位懷抱理想的開發者。'
+                                    : 'A student-led, Google-supported tech hub. We bridge campus and the real world through practical projects, cutting-edge talks and community collaboration to empower every aspiring developer.'}
                             </p>
                         </div>
 
                         {/* 右側：社群連結與聯絡方式 */}
                         <div className={`flex flex-col items-center md:items-end text-center md:text-right gap-y-6 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`} style={{ transitionDelay: '0.7s' }}>
                             <div>
-                                <h3 className="font-bold text-heading mb-4">關注我們</h3>
+                                <h3 className="font-bold text-heading mb-4">{language === 'zh' ? '關注我們' : 'Follow Us'}</h3>
                                 <div className="flex items-center justify-center md:justify-end gap-x-4">
                                     {socialLinks.map((social) => (
                                         <a

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,0 +1,28 @@
+'use client';
+
+// 語言切換按鈕
+import { useLanguage } from '@/hooks/useLanguage';
+
+export default function LanguageSwitcher({ colorClass }) {
+    const { language, toggleLanguage, isLoaded } = useLanguage();
+
+    // 未載入時顯示佔位符避免閃爍
+    if (!isLoaded) {
+        return <div className="p-2 w-9 h-9 rounded-full"></div>;
+    }
+
+    const buttonColorClass = colorClass || 'text-foreground hover:text-brand';
+
+    return (
+        <button
+            onClick={toggleLanguage}
+            className={`p-2 rounded-full transition-all duration-300 hover:scale-110 hover:bg-surface-muted/30 hover:shadow-md ${buttonColorClass}`}
+            aria-label="Toggle language"
+        >
+            <span className="text-sm font-bold">
+                {language === 'zh' ? 'EN' : '中'}
+            </span>
+        </button>
+    );
+}
+

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
 import Image from 'next/image';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
 import bracketsGif from '@/images/stickers/brackets.gif';
 import ThemeSwitcher from './ThemeSwitcher';
+import LanguageSwitcher from './LanguageSwitcher';
 
 export default function Navbar() {
     const [isScrolled, setIsScrolled] = useState(false);
@@ -25,12 +27,20 @@ export default function Navbar() {
         setIsMobileMenuOpen(false);
     };
 
-    const navLinks = [
-        { label: '核心使命', id: 'vision' },
-        { label: '活動回顧', id: 'events' },
-        { label: '校園專案', id: 'projects' },
-        { label: '加入我們', id: 'join' },
-    ];
+    const { language } = useLanguage();
+    const navLinks = language === 'zh'
+        ? [
+            { label: '核心使命', id: 'vision' },
+            { label: '活動回顧', id: 'events' },
+            { label: '校園專案', id: 'projects' },
+            { label: '加入我們', id: 'join' },
+        ]
+        : [
+            { label: 'Our Vision', id: 'vision' },
+            { label: 'Events', id: 'events' },
+            { label: 'Projects', id: 'projects' },
+            { label: 'Join Us', id: 'join' },
+        ];
 
     // 讓導覽列維持毛玻璃效果，僅針對顏色變化做轉場以避免滾動時位置產生位移
     const navClasses = `fixed top-0 left-0 right-0 z-50 backdrop-blur-xl transition-colors duration-300 ${isScrolled || isMobileMenuOpen
@@ -81,11 +91,13 @@ export default function Navbar() {
                                     <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-brand transition-all duration-300 group-hover:w-full"></span>
                                 </button>
                             ))}
+                            <LanguageSwitcher colorClass={themeSwitcherColor} />
                             <ThemeSwitcher colorClass={themeSwitcherColor} />
                         </div>
 
                         {/* 手機版漢堡選單按鈕 */}
                         <div className="md:hidden flex items-center">
+                            <LanguageSwitcher colorClass={themeSwitcherColor} />
                             <ThemeSwitcher colorClass={themeSwitcherColor} />
                             <button
                                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
+import { useLanguage } from '@/hooks/useLanguage';
 
 import next_js_img from '@/images/tech/nextjs.svg'
 import ts_img from '@/images/tech/typescript.svg'
@@ -13,6 +14,7 @@ import vercal_img from '@/images/tech/vercel.svg'
 export default function Projects() {
     const [isVisible, setIsVisible] = useState(false);
     const ref = useRef(null);
+    const { language } = useLanguage();
 
     const techStack = [
         { name: 'Next.js', icon: next_js_img },
@@ -22,40 +24,77 @@ export default function Projects() {
         { name: 'Vercel', icon: vercal_img },
     ];
 
-    const features = [
-        {
-            status: '已上線',
-            title: '生輔組獎助學金平台',
-            description: '整合校內外獎助學金資訊，提供學生一個清晰、易於操作的申請入口。透過智慧篩選與個人化推薦，有效提升資訊透明度與申請效率。',
-            link: 'https://scholarship.ncuesa.org.tw',
-            tags: ['資訊整合', '使用者體驗', '校園服務']
-        },
-        {
-            status: '已上線',
-            title: '代管生輔組 RPage 網站',
-            description: '我們接手並優化了學生生活輔導組的官方資訊頁面，確保資訊的即時更新與準確傳遞，為全校學生提供更可靠的資訊來源。',
-            link: 'https://stuaffweb.ncue.edu.tw/p/412-1039-4293.php',
-            tags: ['網站維護', '資訊發布']
-        },
-        {
-            status: '進行中',
-            title: '宿舍退宿管理系統',
-            description: '旨在數位化及簡化宿舍退宿流程，從申請、檢查到核准全程線上化，減少紙本作業，提升行政效率與學生便利性。',
-            tags: ['流程數位化', '行政效率']
-        },
-        {
-            status: '進行中',
-            title: '生輔組餐券管理系統',
-            description: '建立一套電子餐券系統，方便學生領取、使用，並提供後台數據追蹤，協助校方精準掌握餐券發放與核銷狀況。',
-            tags: ['電子票券', '數據分析']
-        },
-        {
-            status: '規劃中',
-            title: '學生會投票系統',
-            description: '開發一個安全、公正、透明的線上投票平台，用於學生會選舉及重大議題投票，提升學生參與公共事務的便利性與意願。',
-            tags: ['電子投票', '資訊安全']
-        },
-    ];
+    const featureData = {
+        zh: [
+            {
+                status: '已上線',
+                title: '生輔組獎助學金平台',
+                description: '整合校內外獎助學金資訊，提供學生一個清晰、易於操作的申請入口。透過智慧篩選與個人化推薦，有效提升資訊透明度與申請效率。',
+                link: 'https://scholarship.ncuesa.org.tw',
+                tags: ['資訊整合', '使用者體驗', '校園服務']
+            },
+            {
+                status: '已上線',
+                title: '代管生輔組 RPage 網站',
+                description: '我們接手並優化了學生生活輔導組的官方資訊頁面，確保資訊的即時更新與準確傳遞，為全校學生提供更可靠的資訊來源。',
+                link: 'https://stuaffweb.ncue.edu.tw/p/412-1039-4293.php',
+                tags: ['網站維護', '資訊發布']
+            },
+            {
+                status: '進行中',
+                title: '宿舍退宿管理系統',
+                description: '旨在數位化及簡化宿舍退宿流程，從申請、檢查到核准全程線上化，減少紙本作業，提升行政效率與學生便利性。',
+                tags: ['流程數位化', '行政效率']
+            },
+            {
+                status: '進行中',
+                title: '生輔組餐券管理系統',
+                description: '建立一套電子餐券系統，方便學生領取、使用，並提供後台數據追蹤，協助校方精準掌握餐券發放與核銷狀況。',
+                tags: ['電子票券', '數據分析']
+            },
+            {
+                status: '規劃中',
+                title: '學生會投票系統',
+                description: '開發一個安全、公正、透明的線上投票平台，用於學生會選舉及重大議題投票，提升學生參與公共事務的便利性與意願。',
+                tags: ['電子投票', '資訊安全']
+            },
+        ],
+        en: [
+            {
+                status: 'Released',
+                title: 'Scholarship Platform',
+                description: 'Integrates campus and external scholarship information with an easy-to-use interface. Smart filtering and personalized recommendations improve transparency and application efficiency.',
+                link: 'https://scholarship.ncuesa.org.tw',
+                tags: ['Information Integration', 'User Experience', 'Campus Service']
+            },
+            {
+                status: 'Released',
+                title: 'Student Affairs RPage Site',
+                description: 'We maintain and enhance the Student Affairs Division website, ensuring timely updates and accurate information for all students.',
+                link: 'https://stuaffweb.ncue.edu.tw/p/412-1039-4293.php',
+                tags: ['Site Maintenance', 'Information Release']
+            },
+            {
+                status: 'In Progress',
+                title: 'Dorm Checkout System',
+                description: 'Digitizes and streamlines the dorm checkout process from application to approval, reducing paperwork and improving administrative efficiency.',
+                tags: ['Workflow Digitalization', 'Administrative Efficiency']
+            },
+            {
+                status: 'In Progress',
+                title: 'Meal Voucher Management System',
+                description: 'Creates an electronic meal voucher system with backend tracking to help the school monitor distribution and redemption.',
+                tags: ['E-ticket', 'Data Analysis']
+            },
+            {
+                status: 'Planning',
+                title: 'Student Union Voting System',
+                description: 'Develops a secure, fair and transparent online voting platform for elections and major issues, encouraging student participation in public affairs.',
+                tags: ['E-Voting', 'Cybersecurity']
+            },
+        ]
+    };
+    const features = featureData[language];
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -85,10 +124,12 @@ export default function Projects() {
                 {/* --- 區段一：介紹 (RWD 已優化) --- */}
                 <div className="text-center mb-16 md:mb-24">
                     <h2 className={`phone-h1 md:pc-h1 text-heading mb-6 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
-                        你的 Code，運行在校園日常
+                        {language === 'zh' ? '你的 Code，運行在校園日常' : 'Your code powers daily campus life'}
                     </h2>
                     <p className={`phone-liner md:pc-h3 text-muted max-w-3xl mx-auto leading-relaxed transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`} style={{ transitionDelay: '0.2s' }}>
-                        我們不只打造酷炫的專案，更要解決校園的真實問題。從獎學金平台到宿舍管理系統，我們的技術真正服務於每一位同學。
+                        {language === 'zh'
+                            ? '我們不只打造酷炫的專案，更要解決校園的真實問題。從獎學金平台到宿舍管理系統，我們的技術真正服務於每一位同學。'
+                            : 'We build not just cool projects but real solutions for campus problems. From scholarship platforms to dorm systems, our tech serves every student.'}
                     </p>
                 </div>
 
@@ -99,12 +140,20 @@ export default function Projects() {
                         {/* 左側內容 (手機版會在上) */}
                         <div className="p-8 md:p-12 lg:p-16 flex flex-col justify-center order-2 lg:order-1">
                             <div className={`transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`} style={{ transitionDelay: '0.4s' }}>
-                                <h3 className="phone-h3 md:pc-h2 text-brand mb-4 font-bold">精選專案</h3>
-                                <h2 className="phone-h2 md:pc-h1 text-heading mb-6 leading-tight">獎學金資訊平台</h2>
+                                <h3 className="phone-h3 md:pc-h2 text-brand mb-4 font-bold">
+                                    {language === 'zh' ? '精選專案' : 'Featured Project'}
+                                </h3>
+                                <h2 className="phone-h2 md:pc-h1 text-heading mb-6 leading-tight">
+                                    {language === 'zh' ? '獎學金資訊平台' : 'Scholarship Info Platform'}
+                                </h2>
                                 <p className="phone-liner md:pc-liner text-muted mb-8 leading-relaxed">
-                                    整合校內外獎助學金資訊，提供學生一個清晰、易於操作的申請入口。透過智慧篩選與個人化推薦，讓每位同學都能找到適合的獎助學金機會。
+                                    {language === 'zh'
+                                        ? '整合校內外獎助學金資訊，提供學生一個清晰、易於操作的申請入口。透過智慧篩選與個人化推薦，讓每位同學都能找到適合的獎助學金機會。'
+                                        : 'Integrates scholarship information inside and outside campus, giving students a clear and easy application entry. Smart filtering and personalized recommendations help every student find the right opportunities.'}
                                 </p>
-                                <h4 className="phone-liner-bold md:pc-liner-bold text-heading mb-4 font-bold">技術棧</h4>
+                                <h4 className="phone-liner-bold md:pc-liner-bold text-heading mb-4 font-bold">
+                                    {language === 'zh' ? '技術棧' : 'Tech Stack'}
+                                </h4>
                                 {/* [RWD 優化] 跑馬燈在手機上會有更小的間距和圖示 */}
                                 <div className="relative w-full overflow-hidden rounded-lg bg-surface/50">
                                     <div className="marquee-container flex text-foreground whitespace-nowrap">
@@ -157,8 +206,8 @@ export default function Projects() {
                                         <div className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 bg-gradient-to-br from-orange-400 to-red-500 rounded-full mx-auto flex items-center justify-center shadow-lg mb-3 group-hover:scale-110 transition-transform">
                                             <span className="text-white text-xl md:text-2xl lg:text-3xl">🎓</span>
                                         </div>
-                                        <p className="font-semibold text-sm md:text-base text-white leading-tight mb-1 px-2">獎學金平台</p>
-                                        <p className="text-xs md:text-sm text-white/90 px-2">點擊訪問</p>
+                                        <p className="font-semibold text-sm md:text-base text-white leading-tight mb-1 px-2">{language === 'zh' ? '獎學金平台' : 'Scholarship Platform'}</p>
+                                        <p className="text-xs md:text-sm text-white/90 px-2">{language === 'zh' ? '點擊訪問' : 'Visit site'}</p>
                                     </div>
                                 </button>
                             </div>
@@ -168,7 +217,7 @@ export default function Projects() {
 
                 {/* --- 區段三：更多專案 (RWD 已優化) --- */}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mb-16 md:mb-24">
-                    {features.filter(f => f.title !== '生輔組獎助學金平台').map((feature, index) => (
+                    {features.slice(1).map((feature, index) => (
                         <div
                             key={index}
                             className={`bg-surface rounded-2xl border border-border p-6 flex flex-col transition-all duration-500 transform hover:-translate-y-1 hover:shadow-xl ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}
@@ -177,22 +226,29 @@ export default function Projects() {
                             {/* 卡片內容保持不變，它的 RWD 已經做得很好 */}
                             <div className="flex justify-between items-start mb-4">
                                 <h3 className="phone-h3 md:pc-h3 text-heading font-bold leading-tight">{feature.title}</h3>
-                                <span className={`px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap ${feature.status === '已上線' ? 'bg-green-500/20 text-green-700 dark:bg-green-500/10 dark:text-green-400' :
-                                    feature.status === '進行中' ? 'bg-yellow-500/20 text-yellow-700 dark:bg-yellow-500/10 dark:text-yellow-400' :
-                                        'bg-gray-500/20 text-gray-700 dark:bg-gray-500/10 dark:text-gray-400'
-                                    }`}>
-                                    {feature.status}
-                                </span>
+                                  {(() => {
+                                      const statusClass =
+                                          feature.status === '已上線' || feature.status === 'Released'
+                                              ? 'bg-green-500/20 text-green-700 dark:bg-green-500/10 dark:text-green-400'
+                                              : feature.status === '進行中' || feature.status === 'In Progress'
+                                                  ? 'bg-yellow-500/20 text-yellow-700 dark:bg-yellow-500/10 dark:text-yellow-400'
+                                                  : 'bg-gray-500/20 text-gray-700 dark:bg-gray-500/10 dark:text-gray-400';
+                                      return (
+                                          <span className={`px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap ${statusClass}`}>
+                                              {feature.status}
+                                          </span>
+                                      );
+                                  })()}
                             </div>
                             <p className="phone-liner md:pc-liner text-muted mb-4 leading-relaxed flex-grow">{feature.description}</p>
                             <div className="flex flex-wrap gap-2 mb-4">
-                                {feature.tags.map(tag => (
-                                    <span key={tag} className="px-2 py-1 bg-brand/10 text-brand text-xs rounded">{tag}</span>
-                                ))}
+                                  {feature.tags.map(tag => (
+                                      <span key={tag} className="px-2 py-1 bg-brand/10 text-brand text-xs rounded">{tag}</span>
+                                  ))}
                             </div>
                             {feature.link && (
                                 <a href={feature.link} target="_blank" rel="noopener noreferrer" className="phone-liner-bold text-brand hover:text-brand-accent font-medium transition-colors group flex items-center mt-auto">
-                                    查看專案
+                                    {language === 'zh' ? '查看專案' : 'View Project'}
                                     <svg className="w-4 h-4 ml-1 transform group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
                                 </a>
                             )}
@@ -209,7 +265,7 @@ export default function Projects() {
                         <svg aria-hidden="true" className="w-5 h-5 md:w-6 md:h-6 group-hover:rotate-12 transition-transform" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
                         </svg>
-                        <span>探索我們的 GitHub</span>
+                        <span>{language === 'zh' ? '探索我們的 GitHub' : 'Explore our GitHub'}</span>
                     </button>
                 </div>
             </div>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { ArrowUpIcon } from '@heroicons/react/24/solid';
+import { useLanguage } from '@/hooks/useLanguage';
 
 // 懸浮回到頂端按鈕，外圈顯示頁面滾動進度
 export default function ScrollToTop() {
     const [progress, setProgress] = useState(0);
+    const { language } = useLanguage();
 
     useEffect(() => {
         // 計算頁面滾動百分比
@@ -57,7 +59,7 @@ export default function ScrollToTop() {
                 {/* 內部回頂按鈕 */}
                 <button
                     onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-                    aria-label="回到頂端"
+                    aria-label={language === 'zh' ? '回到頂端' : 'Back to top'}
                     className="absolute inset-0 m-2 rounded-full bg-brand text-text-on-brand flex items-center justify-center shadow-lg shadow-brand/30 transition-transform duration-300 hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
                 >
                     <ArrowUpIcon className="w-5 h-5" />

--- a/src/components/Vision.jsx
+++ b/src/components/Vision.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
 // 導入專業的 SVG 圖示
 import {
     CodeBracketSquareIcon,
@@ -11,6 +12,7 @@ import {
 export default function Vision() {
     const [isVisible, setIsVisible] = useState(false);
     const ref = useRef(null);
+    const { language } = useLanguage();
 
     // 動畫觸發的 useEffect hook (保持不變，效果很好)
     useEffect(() => {
@@ -36,23 +38,41 @@ export default function Vision() {
     }, []);
 
     // --- 使用重寫後的專業中文文案和 SVG 圖示 ---
-    const visionCards = [
-        {
-            title: "校園創新與影響力",
-            description: "我們將想法轉化為實際的校園應用。透過與學校的直接合作，我們打造並維護能優化師生日常生活的系統，將 AI 與現代技術帶入校園的核心。",
-            icon: CodeBracketSquareIcon
-        },
-        {
-            title: "成長與知識共享",
-            description: "保持技術領先。從 AI 工作坊到最新框架的深度探討，我們為熱情的開發者們創造一個充滿活力的空間，互相學習、分享專業，共同成長為技術領導者。",
-            icon: AcademicCapIcon
-        },
-        {
-            title: "連結無限機遇",
-            description: "透過獨家資源釋放你的潛力。我們扮演著橋樑的角色，將成員與 Google、業界夥伴的廣大網絡連結。這是你通往導師指導、專案協作和更廣闊機愈的門戶。",
-            icon: GlobeAltIcon
-        }
-    ];
+    const visionCards = language === 'zh'
+        ? [
+            {
+                title: '校園創新與影響力',
+                description: '我們將想法轉化為實際的校園應用。透過與學校的直接合作，我們打造並維護能優化師生日常生活的系統，將 AI 與現代技術帶入校園的核心。',
+                icon: CodeBracketSquareIcon
+            },
+            {
+                title: '成長與知識共享',
+                description: '保持技術領先。從 AI 工作坊到最新框架的深度探討，我們為熱情的開發者們創造一個充滿活力的空間，互相學習、分享專業，共同成長為技術領導者。',
+                icon: AcademicCapIcon
+            },
+            {
+                title: '連結無限機遇',
+                description: '透過獨家資源釋放你的潛力。我們扮演著橋樑的角色，將成員與 Google、業界夥伴的廣大網絡連結。這是你通往導師指導、專案協作和更廣闊機愈的門戶。',
+                icon: GlobeAltIcon
+            }
+        ]
+        : [
+            {
+                title: 'Campus Innovation and Impact',
+                description: 'We turn ideas into real campus applications. By collaborating directly with the university, we build and maintain systems that improve daily life, bringing AI and modern tech to the heart of campus.',
+                icon: CodeBracketSquareIcon
+            },
+            {
+                title: 'Growth and Knowledge Sharing',
+                description: 'Stay at the cutting edge. From AI workshops to deep dives into the latest frameworks, we create an energetic space for passionate developers to learn, share expertise and grow into tech leaders together.',
+                icon: AcademicCapIcon
+            },
+            {
+                title: 'Connecting Endless Opportunities',
+                description: 'Unlock your potential with exclusive resources. We serve as a bridge linking members to Google and industry partners, opening doors to mentorship, project collaboration and broader opportunities.',
+                icon: GlobeAltIcon
+            }
+        ];
 
     return (
         <section id="vision" className="py-20 md:py-32 px-4 md:px-8 bg-transparent" ref={ref}>
@@ -60,11 +80,13 @@ export default function Vision() {
                 {/* Header with Chinese Content */}
                 <div className="text-center mb-16 md:mb-24">
                     <h2 className={`phone-h1 md:pc-h1 text-heading mb-6 md:mb-8 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
-                        我們的願景
+                        {language === 'zh' ? '我們的願景' : 'Our Vision'}
                     </h2>
                     <p className={`phone-liner md:pc-h3 text-muted max-w-4xl mx-auto leading-relaxed transition-all duration-1000 px-4 md:px-0 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
                         style={{ transitionDelay: '0.2s' }}>
-                        在這裡，你的 Code 不只存在於 GitHub，更運行在校園的日常。
+                        {language === 'zh'
+                            ? '在這裡，你的 Code 不只存在於 GitHub，更運行在校園的日常。'
+                            : 'Here, your code lives not only on GitHub but also runs in everyday campus life.'}
                     </p>
                 </div>
 

--- a/src/hooks/useLanguage.jsx
+++ b/src/hooks/useLanguage.jsx
@@ -1,0 +1,47 @@
+'use client';
+
+// 語言切換 Hook 與 Context
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+// 建立語言 Context
+const LanguageContext = createContext();
+
+// 語言提供者
+export function LanguageProvider({ children }) {
+    // 預設語言為中文
+    const [language, setLanguage] = useState('zh');
+    const [isLoaded, setIsLoaded] = useState(false); // 是否已載入
+
+    useEffect(() => {
+        // 讀取 localStorage 中的語言設定
+        const stored = localStorage.getItem('language');
+        setLanguage(stored || 'zh');
+        setIsLoaded(true);
+    }, []);
+
+    useEffect(() => {
+        if (!isLoaded) return;
+        // 根據語言設定 html 的 lang 屬性
+        document.documentElement.setAttribute('lang', language === 'zh' ? 'zh-TW' : 'en');
+    }, [language, isLoaded]);
+
+    // 切換語言
+    const toggleLanguage = useCallback(() => {
+        if (!isLoaded) return; // 尚未載入時不進行切換
+        const newLang = language === 'zh' ? 'en' : 'zh';
+        setLanguage(newLang);
+        localStorage.setItem('language', newLang);
+    }, [language, isLoaded]);
+
+    return (
+        <LanguageContext.Provider value={{ language, toggleLanguage, isLoaded }}>
+            {children}
+        </LanguageContext.Provider>
+    );
+}
+
+// 使用語言 Context 的自訂 Hook
+export function useLanguage() {
+    return useContext(LanguageContext);
+}
+


### PR DESCRIPTION
## Summary
- add global language context with toggle
- place language switcher beside theme switcher
- translate UI text for bilingual interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Source Sans 3`)*

------
https://chatgpt.com/codex/tasks/task_e_68b520e00a288323bdbe1d237d744430