### PR TITLE
調整回到頂端進度環色彩以提升辨識度

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -42,13 +42,13 @@ export default function ScrollToTop() {
                         stroke="currentColor"
                         fill="none"
                     />
-                    {/* 進度圓環 */}
+                    {/* 進度圓環，改用醒目的強調色避免與背景混淆 */}
                     <circle
                         cx="50"
                         cy="50"
                         r="45"
                         strokeWidth="8"
-                        className="text-brand"
+                        className="text-accent"
                         stroke="currentColor"
                         fill="none"
                         strokeLinecap="round"


### PR DESCRIPTION
## Summary
- 使用 `accent` 色彩顯示回到頂端按鈕的進度圓環，避免與背景混淆

## Testing
- `npm run build` *(失敗：無法下載字體資源)*

------
https://chatgpt.com/codex/tasks/task_e_68b536ead8ec8323a4eb7351d6763f1d