### PR TITLE
feat: add calendar section

### DIFF
--- a/COMPONENTS_SUMMARY.md
+++ b/COMPONENTS_SUMMARY.md
@@ -48,7 +48,14 @@
   - 項目狀態列表（已上線/規劃中）
   - Mockup 設計預覽
 
-### 6. **JoinUs** (`/src/components/JoinUs.jsx`)
+### 6. **Calendar** (`/src/components/Calendar.jsx`)
+- **功能**: 官方行事曆展示
+- **特色**:
+  - Google Calendar 嵌入式視圖
+  - 依主題切換背景顏色
+  - 響應式高度與淡入動畫
+
+### 7. **JoinUs** (`/src/components/JoinUs.jsx`)
 - **功能**: 加入我們 + Footer
 - **特色**:
   - 雙區段設計（藍色 CTA + 黑色 Footer）

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -3,6 +3,7 @@ import Hero from '@/components/Hero';
 import Vision from '@/components/Vision';
 import Events from '@/components/Events';
 import Projects from '@/components/Projects';
+import Calendar from '@/components/Calendar';
 import JoinUs from '@/components/JoinUs';
 
 export default function Home() {
@@ -13,6 +14,7 @@ export default function Home() {
       <Vision />
       <Events />
       <Projects />
+      <Calendar />
       <JoinUs />
     </main>
   );

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,0 +1,48 @@
+'use client';
+
+// 行事曆區塊，嵌入 Google Calendar，支援亮暗色主題與 RWD
+import { useState, useEffect, useRef } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
+
+export default function Calendar() {
+    const ref = useRef(null);
+    const [isVisible, setIsVisible] = useState(false);
+    const { language } = useLanguage();
+    const { theme } = useTheme();
+
+    // 進入視窗時啟用淡入效果
+    useEffect(() => {
+        const observer = new IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+                setIsVisible(true);
+                observer.unobserve(entry.target);
+            }
+        }, { threshold: 0.1 });
+
+        if (ref.current) observer.observe(ref.current);
+        return () => { if (ref.current) observer.unobserve(ref.current); };
+    }, []);
+
+    // 根據主題切換 Google Calendar 背景顏色
+    const calendarSrc = `https://calendar.google.com/calendar/embed?src=c_c9a15fa8927d18cb8a0729ce86aa1801a579a04d11368df860950c15f6c04af4%40group.calendar.google.com&ctz=Asia%2FTaipei&bgcolor=${theme === 'dark' ? '%23121212' : '%23ffffff'}`;
+
+    return (
+        <section id="calendar" className="bg-surface-muted py-20 md:py-32 px-4 md:px-6" ref={ref}>
+            <div className={`max-w-5xl mx-auto transition-opacity duration-1000 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
+                <h2 className="phone-h1 md:pc-h2 text-heading text-center mb-8">
+                    {language === 'zh' ? '行事曆' : 'Calendar'}
+                </h2>
+                <div className="rounded-xl overflow-hidden shadow-lg border border-border">
+                    <iframe
+                        src={calendarSrc}
+                        className="w-full h-[500px] md:h-[700px]"
+                        frameBorder="0"
+                        scrolling="no"
+                    />
+                </div>
+            </div>
+        </section>
+    );
+}
+


### PR DESCRIPTION
## Summary
- embed Google Calendar with light/dark theme and responsive design
- insert calendar section before JoinUs block
- update components summary

## Testing
- `npm run build` *(fails: Failed to fetch font `Source Sans 3` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b53b43e71c8323943cde9b42f532c9