### PR TITLE
fix: toggle calendar inversion mask with theme

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -38,8 +38,8 @@ export default function Calendar() {
                     <iframe
                         src={calendarSrc}
                         className="w-full h-[500px] md:h-[700px]"
-                        /* 暗色主題時套用 CSS 濾鏡反轉色彩 */
-                        style={{ filter: theme === 'dark' ? 'invert(1) hue-rotate(180deg)' : undefined }}
+                        /* 根據主題套用或移除色彩反轉遮罩 */
+                        style={{ filter: theme === 'dark' ? 'invert(1) hue-rotate(180deg)' : 'none' }}
                         frameBorder="0"
                         scrolling="no"
                     />


### PR DESCRIPTION
## Summary
- ensure Google Calendar iframe disables inversion on light theme

## Testing
- `npm run build` *(fails: Failed to fetch `Source Sans 3` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5408f61e88323ad873b86bf94d9bd