### PR TITLE
fix: prevent horizontal scroll on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,13 @@
   --text-on-brand: #202124;
 }
 
+html,
+body {
+  /* 防止頁面在手機上左右滾動 */
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
## Summary
- prevent horizontal scroll on mobile by limiting root width and hiding overflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b54421096c8323884e950c36d579ec