### PR TITLE
fix: stabilize theme switching on home page

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -34,6 +34,7 @@ export default function Calendar() {
                 </h2>
                 <div className="rounded-xl overflow-hidden shadow-lg border border-border relative">
                     <iframe
+                        key={theme} // 主題切換時重新載入以套用濾鏡
                         src={calendarSrc}
                         className="w-full h-[500px] md:h-[700px]"
                         /* 根據主題套用或移除色彩反轉遮罩 */

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -102,7 +102,16 @@ export default function Hero() {
                 <h1
                     className={`mb-6 transition-all duration-1000 drop-shadow-lg leading-tight ${isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
                         }`}
-                    style={{ 
+                    style={theme === 'light' ? {
+                        // 亮色主題改為深色文字
+                        fontSize: 'clamp(3rem, 8vw, 8rem)',
+                        fontWeight: '700',
+                        fontFamily: 'var(--font-source-sans)',
+                        color: 'var(--heading)',
+                        textShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+                        transitionDelay: '0.3s'
+                    } : {
+                        // 暗色主題維持彩色漸層文字
                         fontSize: 'clamp(3rem, 8vw, 8rem)',
                         fontWeight: '700',
                         fontFamily: 'var(--font-source-sans)',
@@ -121,7 +130,16 @@ export default function Hero() {
                 <h2
                     className={`mb-8 md:mb-10 transition-all duration-1000 drop-shadow-md leading-relaxed ${isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
                         }`}
-                    style={{ 
+                    style={theme === 'light' ? {
+                        // 亮色主題使用深色文字
+                        fontSize: 'clamp(1.5rem, 4vw, 3rem)',
+                        fontWeight: '600',
+                        fontFamily: 'var(--font-source-sans)',
+                        color: 'var(--heading)',
+                        textShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+        transitionDelay: '0.6s'
+                    } : {
+                        // 暗色主題維持淡色漸層
                         fontSize: 'clamp(1.5rem, 4vw, 3rem)',
                         fontWeight: '600',
                         fontFamily: 'var(--font-source-sans)',

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
 import Image from 'next/image';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
 import bracketsGif from '@/images/stickers/brackets.gif';
@@ -11,6 +12,7 @@ import LanguageSwitcher from './LanguageSwitcher';
 export default function Navbar() {
     const [isScrolled, setIsScrolled] = useState(false);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const { theme } = useTheme();
 
     useEffect(() => {
         const handleScroll = () => {
@@ -50,11 +52,17 @@ export default function Navbar() {
             : 'bg-surface/50'
         }`;
 
-    const logoColor = isScrolled || isMobileMenuOpen ? 'text-heading' : 'text-white drop-shadow-lg';
-    const linkColor = isScrolled || isMobileMenuOpen ? 'text-muted hover:text-heading' : 'text-white hover:text-gray-200 drop-shadow-md';
+    // 依據主題與滾動狀態決定顏色
+    const baseLogoColor = theme === 'light' ? 'text-heading' : 'text-white drop-shadow-lg';
+    const baseLinkColor = theme === 'light' ? 'text-muted hover:text-heading' : 'text-white hover:text-gray-200 drop-shadow-md';
+    const baseIconColor = theme === 'light' ? 'text-heading' : 'text-white';
+    const baseSwitcherColor = theme === 'light' ? 'text-heading hover:text-brand' : 'text-white hover:text-gray-200 drop-shadow-md';
+
+    const logoColor = isScrolled || isMobileMenuOpen ? 'text-heading' : baseLogoColor;
+    const linkColor = isScrolled || isMobileMenuOpen ? 'text-muted hover:text-heading' : baseLinkColor;
     // 根據滾動與漢堡選單狀態切換 icon 顏色
-    const mobileIconColor = isScrolled || isMobileMenuOpen ? 'text-heading' : 'text-white';
-    const themeSwitcherColor = isScrolled || isMobileMenuOpen ? 'text-heading hover:text-brand' : 'text-white hover:text-gray-200 drop-shadow-md';
+    const mobileIconColor = isScrolled || isMobileMenuOpen ? 'text-heading' : baseIconColor;
+    const themeSwitcherColor = isScrolled || isMobileMenuOpen ? 'text-heading hover:text-brand' : baseSwitcherColor;
 
     return (
         <>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -3,11 +3,13 @@
 import { useEffect, useState } from 'react';
 import { ArrowUpIcon } from '@heroicons/react/24/solid';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useTheme } from '@/hooks/useTheme';
 
 // 懸浮回到頂端按鈕，外圈顯示頁面滾動進度
 export default function ScrollToTop() {
     const [progress, setProgress] = useState(0);
     const { language } = useLanguage();
+    const { theme } = useTheme();
 
     useEffect(() => {
         // 計算頁面滾動百分比
@@ -32,13 +34,13 @@ export default function ScrollToTop() {
             <div className="relative w-14 h-14">
                 {/* 使用 SVG 繪製圓周進度環 */}
                 <svg className="absolute inset-0 w-full h-full transform -rotate-90" viewBox="0 0 100 100">
-                    {/* 背景圓環 */}
+                    {/* 背景圓環：亮色主題使用較深色避免不明顯 */}
                     <circle
                         cx="50"
                         cy="50"
                         r="45"
                         strokeWidth="8"
-                        className="text-border"
+                        className={theme === 'light' ? 'text-muted' : 'text-border'}
                         stroke="currentColor"
                         fill="none"
                     />

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -3,31 +3,25 @@
 import { useState, useEffect, useCallback } from 'react';
 
 export const useTheme = () => {
-    const [theme, setTheme] = useState(null); // 初始為 null 避免閃爍
+    const [theme, setTheme] = useState(() => {
+        // 從 <html> 取得目前主題，避免重新載入時閃爍
+        if (typeof document !== 'undefined') {
+            return document.documentElement.getAttribute('data-theme') || 'light';
+        }
+        return 'light';
+    });
     const [isLoaded, setIsLoaded] = useState(false);
 
     useEffect(() => {
-        // 檢查系統偏好
-        const getInitialTheme = () => {
-            if (typeof window !== 'undefined') {
-                const storedTheme = localStorage.getItem('theme');
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                // 如果沒有儲存的主題，使用系統偏好
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            }
-            return 'light';
-        };
-
-        const initialTheme = getInitialTheme();
-        setTheme(initialTheme);
-        document.documentElement.setAttribute('data-theme', initialTheme);
+        // 初始化時標記為已載入，並確保 localStorage 有主題設定
+        if (typeof window !== 'undefined' && !localStorage.getItem('theme')) {
+            localStorage.setItem('theme', theme);
+        }
         setIsLoaded(true);
-    }, []);
+    }, [theme]);
 
     const toggleTheme = useCallback(() => {
-        if (!isLoaded) return; // 防止在未加載完成時切換
+        if (!isLoaded) return; // 防止在未載入完成前切換
         
         const newTheme = theme === 'light' ? 'dark' : 'light';
         setTheme(newTheme);


### PR DESCRIPTION
## Summary
- ensure theme state syncs with HTML to avoid reload mismatches
- adjust hero and navbar colors for light mode
- refine scroll-to-top and calendar to respond to theme

## Testing
- `npm run build` *(fails: Failed to fetch font Source Sans 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b5460f36a4832393c2bc7bb83c1c6c