### PR TITLE
調整願景區塊觸發範圍，改善手機顯示

### DIFF
--- a/src/components/Vision.jsx
+++ b/src/components/Vision.jsx
@@ -21,8 +21,8 @@ export default function Vision() {
                 // 依據可見狀態切換動畫
                 setIsVisible(entry.isIntersecting);
             },
-            // threshold 設為 1 代表元素完全進入視窗才觸發
-            { threshold: 1 }
+            // 將 threshold 降至 0.2 並擴大 rootMargin，讓區塊在部分進出視窗時仍能保持顯示
+            { threshold: 0.2, rootMargin: '20% 0px 20% 0px' }
         );
 
         if (ref.current) {


### PR DESCRIPTION
## Summary
- 降低 `Vision` 區塊的 `IntersectionObserver` 閾值並擴大 `rootMargin`，避免手機版一滾動就消失

## Testing
- `npm run build` *(失敗：無法從 Google Fonts 下載 Source Sans 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b547c0955c832385ba0f35e65e135a