### PR TITLE
feat: add 3D hover and sheen effect to vision cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -386,3 +386,17 @@ html {
     max-width: 100%;
   }
 }
+
+/* Vision Card Sheen Effect */
+.sheen {
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(55deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0) 100%);
+  transform: translateX(-100%) rotate(45deg);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.4s ease-out, opacity 0.4s ease-out;
+}


### PR DESCRIPTION
## Summary
- add interactive parallax tilt and sheen sweep to vision cards
- center card icons and text on desktop
- include global sheen style for card reflections

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b69afd8e6083239b31981d250cf564