### PR TITLE
移除 Hero 模糊遮罩並調整淺色主題行為

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -107,8 +107,10 @@ export default function Hero() {
             {/* 背景元件：不再需要傳遞 theme prop */}
             <MatrixBackground codeString={heroComponentCode} />
 
-            {/* 遮罩層：確保在不同主題下，前景文字都清晰可見 */}
-            <div className={`absolute inset-0 z-8 ${theme === 'dark' ? 'bg-black/60' : 'bg-white/30 backdrop-blur-sm'}`}></div>
+            {/* 遮罩層：僅在深色主題下提供黑色半透明遮罩，淺色主題不套用模糊遮罩 */}
+            {theme === 'dark' && (
+                <div className="absolute inset-0 z-8 bg-black/60"></div>
+            )}
 
             {/* 前景內容 */}
             <div className="relative z-20 text-center px-4 md:px-6">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -45,7 +45,7 @@ export default function Navbar() {
             { label: 'Join Us', id: 'join' },
         ];
     
-    // === 根據主題與捲動狀態判斷是否使用淺色樣式 ===
+    // 在淺色主題下，僅在捲動或展開選單時改用淺色樣式，否則維持深色樣式
     const useLightStyle = theme === 'light' && (isScrolled || isMobileMenuOpen);
 
     const navClasses = `fixed top-0 left-0 right-0 z-50 backdrop-blur-xl transition-colors duration-300 ${isScrolled || isMobileMenuOpen

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -31,7 +31,7 @@ export default function ScrollToTop() {
         };
     }, []);
 
-    // 在淺色主題下，離開 Hero 後改用淺色樣式
+    // 在淺色主題下，未捲動前保持深色樣式，捲動後改用淺色樣式
     const useLightStyle = theme === 'light' && isScrolled;
 
     return (


### PR DESCRIPTION
## Summary
- 移除淺色主題下 Hero 的模糊遮罩
- 補充註解，說明淺色主題初始仍採用深色樣式的行為

## Testing
- `npm run build` *(失敗：無法下載 Google Fonts Source Sans 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b69c60bb7c8323a60d396369e42dc4