### PR TITLE
fix: ensure hero theme overlay updates correctly

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -2,6 +2,7 @@ import { Source_Sans_3 } from "next/font/google";
 import "./globals.css";
 import ScrollToTop from '@/components/ScrollToTop';
 import { LanguageProvider } from '@/hooks/useLanguage';
+import { ThemeProvider } from '@/hooks/useTheme';
 
 const sourceSans = Source_Sans_3({
   variable: "--font-source-sans",
@@ -36,12 +37,14 @@ export default function RootLayout({ children }) {
         />
       </head>
       <body className={`${sourceSans.variable} antialiased`}>
-        <LanguageProvider>
-          <div className="fixed inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
-          <div className="fixed inset-0 -z-20 h-full w-full bg-background [mask-image:radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"></div>
-          {children}
-          <ScrollToTop />
-        </LanguageProvider>
+        <ThemeProvider>
+          <LanguageProvider>
+            <div className="fixed inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+            <div className="fixed inset-0 -z-20 h-full w-full bg-background [mask-image:radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"></div>
+            {children}
+            <ScrollToTop />
+          </LanguageProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -109,7 +109,8 @@ export default function Hero() {
 
             {/* 遮罩層：僅在深色主題下提供黑色半透明遮罩，淺色主題不套用模糊遮罩 */}
             {theme === 'dark' && (
-                <div className="absolute inset-0 z-8 bg-black/60"></div>
+                // 深色主題下的遮罩層，確保位於背景與內容之間
+                <div className="absolute inset-0 z-10 bg-black/60"></div>
             )}
 
             {/* 前景內容 */}

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -1,39 +1,47 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+// 主題切換 Hook 與 Context
+// 使用 React Context 讓所有元件共享主題狀態
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 
-export const useTheme = () => {
-    const [theme, setTheme] = useState(null); // 初始為 null 避免閃爍
-    const [isLoaded, setIsLoaded] = useState(false);
+// 建立主題 Context
+const ThemeContext = createContext();
+
+// 主題提供者，負責管理主題狀態
+export function ThemeProvider({ children }) {
+    const [theme, setTheme] = useState('light'); // 預設為淺色主題
+    const [isLoaded, setIsLoaded] = useState(false); // 是否已載入完成
 
     useEffect(() => {
-        // 檢查系統偏好
-        const getInitialTheme = () => {
-            if (typeof window !== 'undefined') {
-                const storedTheme = localStorage.getItem('theme');
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                // 如果沒有儲存的主題，使用系統偏好
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            }
-            return 'light';
-        };
+        // 讀取本地儲存或系統偏好的主題設定
+        const storedTheme = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
 
-        const initialTheme = getInitialTheme();
         setTheme(initialTheme);
         document.documentElement.setAttribute('data-theme', initialTheme);
         setIsLoaded(true);
     }, []);
 
+    // 切換主題
     const toggleTheme = useCallback(() => {
-        if (!isLoaded) return; // 防止在未加載完成時切換
-        
+        if (!isLoaded) return; // 尚未載入時不進行切換
+
         const newTheme = theme === 'light' ? 'dark' : 'light';
         setTheme(newTheme);
         localStorage.setItem('theme', newTheme);
         document.documentElement.setAttribute('data-theme', newTheme);
     }, [theme, isLoaded]);
 
-    return { theme: theme || 'light', toggleTheme, isLoaded };
-};
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme, isLoaded }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+// 使用主題 Context 的自訂 Hook
+export function useTheme() {
+    return useContext(ThemeContext);
+}
+


### PR DESCRIPTION
## Summary
- share theme state across app with `ThemeProvider`
- wrap app with `ThemeProvider` and adjust hero overlay stacking

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6da290b088323b17a3c9dc7f0ec79