### PR TITLE
fix: 主題切換同步行事曆遮罩

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -2,6 +2,7 @@ import { Source_Sans_3 } from "next/font/google";
 import "./globals.css";
 import ScrollToTop from '@/components/ScrollToTop';
 import { LanguageProvider } from '@/hooks/useLanguage';
+import { ThemeProvider } from '@/hooks/useTheme';
 
 const sourceSans = Source_Sans_3({
   variable: "--font-source-sans",
@@ -37,10 +38,12 @@ export default function RootLayout({ children }) {
       </head>
       <body className={`${sourceSans.variable} antialiased`}>
         <LanguageProvider>
-          <div className="fixed inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
-          <div className="fixed inset-0 -z-20 h-full w-full bg-background [mask-image:radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"></div>
-          {children}
-          <ScrollToTop />
+          <ThemeProvider>
+            <div className="fixed inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+            <div className="fixed inset-0 -z-20 h-full w-full bg-background [mask-image:radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"></div>
+            {children}
+            <ScrollToTop />
+          </ThemeProvider>
         </LanguageProvider>
       </body>
     </html>

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -1,39 +1,47 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+// 主題 Context 及提供器，讓全站元件能共享主題狀態
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 
-export const useTheme = () => {
-    const [theme, setTheme] = useState(null); // 初始為 null 避免閃爍
+// 建立 Context
+const ThemeContext = createContext();
+
+// 主題提供器，包裹在最外層以共享狀態
+export function ThemeProvider({ children }) {
+    // 使用 null 作為初始值避免水合時閃爍
+    const [theme, setTheme] = useState(null);
     const [isLoaded, setIsLoaded] = useState(false);
 
+    // 初始化主題，優先使用 localStorage，其次使用系統偏好
     useEffect(() => {
-        // 檢查系統偏好
-        const getInitialTheme = () => {
-            if (typeof window !== 'undefined') {
-                const storedTheme = localStorage.getItem('theme');
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                // 如果沒有儲存的主題，使用系統偏好
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            }
-            return 'light';
-        };
+        const storedTheme = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+        const systemPrefersDark = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const initialTheme = storedTheme || (systemPrefersDark ? 'dark' : 'light');
 
-        const initialTheme = getInitialTheme();
         setTheme(initialTheme);
         document.documentElement.setAttribute('data-theme', initialTheme);
         setIsLoaded(true);
     }, []);
 
+    // 切換主題並同步到 localStorage 與 html 屬性
     const toggleTheme = useCallback(() => {
-        if (!isLoaded) return; // 防止在未加載完成時切換
-        
+        if (!isLoaded) return; // 尚未載入完成時不允許切換
+
         const newTheme = theme === 'light' ? 'dark' : 'light';
         setTheme(newTheme);
         localStorage.setItem('theme', newTheme);
         document.documentElement.setAttribute('data-theme', newTheme);
     }, [theme, isLoaded]);
 
-    return { theme: theme || 'light', toggleTheme, isLoaded };
+    return (
+        <ThemeContext.Provider value={{ theme: theme || 'light', toggleTheme, isLoaded }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+// 自訂 Hook，讓元件可讀取或切換主題
+export const useTheme = () => {
+    return useContext(ThemeContext);
 };
+


### PR DESCRIPTION
## Summary
- 建立 ThemeProvider 共享主題狀態，切換後立即生效
- 在全域佈局中注入 ThemeProvider 以同步行事曆遮罩

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Failed to fetch font `Source Sans 3`)


------
https://chatgpt.com/codex/tasks/task_e_68b6db643b2c8323925d8f04ef3d30ad