### PR TITLE
feat: 根據裝置語言預設網站語言

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -22,6 +22,24 @@ export default function RootLayout({ children }) {
   return (
     <html lang="zh-TW" suppressHydrationWarning>
       <head>
+        {/* 在載入前設定語言 */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var lang = localStorage.getItem('language');
+                  if (!lang) {
+                    var userLang = navigator.language || 'en';
+                    lang = userLang.startsWith('zh') ? 'zh' : 'en';
+                    localStorage.setItem('language', lang);
+                  }
+                  document.documentElement.setAttribute('lang', lang === 'zh' ? 'zh-TW' : 'en');
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/src/hooks/useLanguage.jsx
+++ b/src/hooks/useLanguage.jsx
@@ -8,14 +8,21 @@ const LanguageContext = createContext();
 
 // 語言提供者
 export function LanguageProvider({ children }) {
-    // 預設語言為中文
+    // 預設語言由使用者裝置語言決定，若無則為中文
     const [language, setLanguage] = useState('zh');
     const [isLoaded, setIsLoaded] = useState(false); // 是否已載入
 
     useEffect(() => {
-        // 讀取 localStorage 中的語言設定
+        // 讀取 localStorage 中的語言設定，若無則依裝置語言判斷
         const stored = localStorage.getItem('language');
-        setLanguage(stored || 'zh');
+        if (stored) {
+            setLanguage(stored);
+        } else {
+            const deviceLang = navigator.language || 'en';
+            const defaultLang = deviceLang.startsWith('zh') ? 'zh' : 'en';
+            setLanguage(defaultLang);
+            localStorage.setItem('language', defaultLang);
+        }
         setIsLoaded(true);
     }, []);
 


### PR DESCRIPTION
## Summary
- 初始化時檢查使用者裝置語言，未設定時自動於 localStorage 儲存並套用
- 於頁面載入前即設定 `<html lang>`，確保語言屬性正確

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Failed to fetch font `Source Sans 3` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68b6dc1005a083238477eac01948d6ca