### PR TITLE
修正願景卡片手機版的模糊與滾動體驗

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -312,6 +312,16 @@ html {
   animation: float-reverse 8s ease-in-out infinite;
 }
 
+/* 隱藏滾動條 */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 /* 響應式工具類 */
 .mobile-optimized {
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- 以容器中心計算模糊與縮放，確保中央卡片清晰
- 加入滾輪事件，手機版先橫向捲動再允許往下
- 隱藏願景區塊的捲動條

## Testing
- `npm run build` *(失敗：Failed to fetch font `Source Sans 3`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dd934c988323aa327e75cf240355