### PR TITLE
feat: always use dark navbar on light theme

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -45,8 +45,8 @@ export default function Navbar() {
             { label: 'Join Us', id: 'join' },
         ];
     
-    // 在頂端一律使用淺色元件，僅在淺色主題且頁面已滾動時切換為深色元件
-    const useDarkStyle = theme === 'light' && isScrolled;
+    // 在淺色主題下無論是否位於頂端皆套用深色元件
+    const useDarkStyle = theme === 'light';
 
     const navClasses = `fixed top-0 left-0 right-0 z-50 backdrop-blur-xl transition-colors duration-300 ${isScrolled || isMobileMenuOpen
             ? 'bg-surface/90 shadow-lg'


### PR DESCRIPTION
## Summary
- apply dark navbar styling whenever light theme is active

## Testing
- `npm run build` *(fails: Failed to fetch font `Source Sans 3`)*

------
https://chatgpt.com/codex/tasks/task_e_68b711b8f37c8323ba1b275ffe24e079