### PR TITLE
feat: 將手機版語言切換移至選單底部

### DIFF
--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -8,7 +8,7 @@ export default function LanguageSwitcher({ colorClass }) {
 
     // 未載入時顯示佔位符避免閃爍
     if (!isLoaded) {
-        return <div className="p-2 w-9 h-9 rounded-full"></div>;
+        return <div className="p-2 w-16 h-9 rounded-full"></div>;
     }
 
     const buttonColorClass = colorClass || 'text-foreground hover:text-brand';
@@ -16,11 +16,13 @@ export default function LanguageSwitcher({ colorClass }) {
     return (
         <button
             onClick={toggleLanguage}
-            className={`p-2 rounded-full transition-all duration-300 hover:scale-110 hover:bg-surface-muted/30 hover:shadow-md ${buttonColorClass}`}
-            aria-label="Toggle language"
+            className={`px-3 py-2 rounded-full transition-all duration-300 hover:scale-105 hover:bg-surface-muted/30 hover:shadow-md ${buttonColorClass}`}
+            aria-label="切換語言"
         >
             <span className="text-sm font-bold">
-                {language === 'zh' ? 'EN' : '中'}
+                <span className={language === 'zh' ? 'text-brand' : ''}>中</span>
+                <span className="mx-1">/</span>
+                <span className={language === 'en' ? 'text-brand' : ''}>Eng</span>
             </span>
         </button>
     );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -98,7 +98,6 @@ export default function Navbar() {
                         </div>
 
                         <div className="md:hidden flex items-center">
-                            <LanguageSwitcher colorClass={themeSwitcherColor} />
                             <ThemeSwitcher colorClass={themeSwitcherColor} />
                             <button
                                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
@@ -125,6 +124,10 @@ export default function Navbar() {
                                 {label}
                             </button>
                         ))}
+                        {/* 手機版選單底部的語言切換 */}
+                        <div className="pt-2 border-t border-surface-muted flex justify-center">
+                            <LanguageSwitcher colorClass={mobileMenuItemColor} />
+                        </div>
                     </div>
                 </div>
             </nav>


### PR DESCRIPTION
## Summary
- 在手機版漢堡選單底部新增語言切換按鈕
- 語言切換按鈕顯示「中 / Eng」並突顯目前語系

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Failed to fetch font `Source Sans 3` from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68b716e034c883239f759db78132f437