### PR TITLE
修復手機選單語言切換未顯示

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -111,8 +111,9 @@ export default function Navbar() {
                     </div>
                 </div>
 
+                {/* 增加最大高度以確保手機版選單底部可以顯示語言切換按鈕 */}
                 <div
-                    className={`md:hidden overflow-hidden transition-[max-height] duration-300 ease-in-out ${isMobileMenuOpen ? 'max-h-64 shadow-lg' : 'max-h-0'}`}
+                    className={`md:hidden overflow-hidden transition-[max-height] duration-300 ease-in-out ${isMobileMenuOpen ? 'max-h-96 shadow-lg' : 'max-h-0'}`}
                 >
                     <div className="p-4 space-y-4">
                         {navLinks.map(({ label, id }) => (


### PR DESCRIPTION
## Summary
- 擴增手機版選單展開的最大高度，讓語言切換按鈕得以顯示

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch `Source Sans 3` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7192a6c9c8323921235592533c3fd