### PR TITLE
style: 讓下落程式碼文字在所有主題為綠色

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,9 +16,9 @@
   --warn: #fbbc04;
   --text-on-brand: #ffffff;
   --matrix-bg: rgba(255, 255, 255, 0.1); /* 原為 0.45 */
-    --matrix-head: #000000;
-    --matrix-default: #334155;
-    --matrix-brackets: #0055A4;
+    --matrix-head: #39FF14; /* 下落文字主色改為綠色 */
+    --matrix-default: #39FF14; /* 下落文字預設色改為綠色 */
+    --matrix-brackets: #39FF14; /* 下落括號顏色改為綠色 */
 
   /* Font Variables */
   --font-source-sans: 'Source Sans 3', 'Source Sans Pro', Arial, Helvetica, sans-serif;
@@ -39,9 +39,9 @@
   --warn: #fdd663;
   --text-on-brand: #202124;
   --matrix-bg: rgba(0, 0, 0, 0.05); /* 原為 0.3 */
-    --matrix-head: #C7FFD8;
-    --matrix-default: #39FF14;
-    --matrix-brackets: '#FFD700'; /* 確保引號正確 */
+    --matrix-head: #39FF14; /* 下落文字主色改為綠色 */
+    --matrix-default: #39FF14; /* 下落文字預設色改為綠色 */
+    --matrix-brackets: #39FF14; /* 下落括號顏色改為綠色 */
 }
 
 html,


### PR DESCRIPTION
## Summary
- 將 Matrix 背景的文字顏色統一為綠色，支援亮色與暗色主題

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch font `Source Sans 3`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a7ece59c8323aa1efaaf8856cfd7