### PR TITLE
chore: darken matrix text in light theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,9 +16,9 @@
   --warn: #fbbc04;
   --text-on-brand: #ffffff;
   --matrix-bg: rgba(255, 255, 255, 0.1); /* 原為 0.45 */
-    --matrix-head: #39FF14; /* 下落文字主色改為綠色 */
-    --matrix-default: #39FF14; /* 下落文字預設色改為綠色 */
-    --matrix-brackets: #39FF14; /* 下落括號顏色改為綠色 */
+  --matrix-head: #006400; /* 下落文字主色改為深綠色 */
+  --matrix-default: #006400; /* 下落文字預設色改為深綠色 */
+  --matrix-brackets: #006400; /* 下落括號顏色改為深綠色 */
 
   /* Font Variables */
   --font-source-sans: 'Source Sans 3', 'Source Sans Pro', Arial, Helvetica, sans-serif;


### PR DESCRIPTION
## Summary
- darken matrix falling code color for light theme

## Testing
- `npm run build -- --no-lint` *(fails: Failed to fetch Source Sans 3 from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7aecff0348323b763e14c701a4163