### PR TITLE
Disable selection and dragging on homepage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -472,3 +472,10 @@ html {
   background-clip: text;
   color: transparent;
 }
+
+/* 禁止拖曳與選取所有圖片與圖示 */
+img,
+svg {
+  -webkit-user-drag: none;
+  user-select: none;
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -8,7 +8,8 @@ import JoinUs from '@/components/JoinUs';
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-screen select-none">
+      {/* 禁止首頁文字與圖示被選取 */}
       <Navbar />
       <Hero />
       <Vision />

--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -91,6 +91,7 @@ export default function Events() {
                                                 fill
                                                 sizes="100vw"
                                                 className="object-cover transition-transform duration-500 group-hover:scale-105"
+                                                draggable={false}
                                                 onError={(e) => {
                                                     // 如果圖片加載失敗，隱藏 img 並顯示同父容器內的佔位符
                                                     try {
@@ -140,6 +141,7 @@ export default function Events() {
                                     width={40}
                                     height={40}
                                     className="w-8 h-8 md:w-10 md:h-10 object-contain"
+                                    draggable={false}
                                 />
                                 <p className="phone-liner-bold md:pc-liner-bold text-brand">
                                     {language === 'zh' ? '回顧我們的「Build with AI 2025」' : 'Review of "Build with AI 2025"'}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -146,6 +146,7 @@ export default function Hero() {
                         width={48}
                         height={48}
                         className="w-12 h-12 md:w-20 md:h-20 object-contain"
+                        draggable={false}
                     />
                     <span className={`text-lg md:text-2xl font-bold ${theme === 'light' ? 'text-slate-800' : 'text-white'}`}>
                         {language === 'zh' ? '探索我們的故事' : 'Explore Our Story'}

--- a/src/components/JoinUs.jsx
+++ b/src/components/JoinUs.jsx
@@ -109,7 +109,14 @@ export default function JoinUs() {
                         className={`w-full md:w-auto inline-flex items-center justify-center gap-x-3 md:gap-x-4 bg-brand text-text-on-brand font-bold phone-liner-bold md:pc-liner-bold px-8 py-4 md:px-10 md:py-5 rounded-xl shadow-lg shadow-brand/30 transition-all duration-300 transform hover:scale-105 hover:shadow-xl hover:shadow-brand/50 ${isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}`}
                         style={{ transitionDelay: '0.4s' }}
                     >
-                        <Image src={lineIcon} alt="Line Icon" width={28} height={28} className="w-6 h-6 md:w-7 md:h-7" />
+                        <Image
+                            src={lineIcon}
+                            alt="Line Icon"
+                            width={28}
+                            height={28}
+                            className="w-6 h-6 md:w-7 md:h-7"
+                            draggable={false}
+                        />
                         <span>{language === 'zh' ? '立即加入 LINE 社群' : 'Join our LINE group now'}</span>
                         <ArrowRightIcon className="w-5 h-5 md:w-6 md:h-6" />
                     </button>
@@ -133,6 +140,7 @@ export default function JoinUs() {
                                     alt="GDG on Campus NCUE Logo"
                                     width={350}
                                     height={70}
+                                    draggable={false}
                                 />
                             </a>
                             <p className="text-muted text-sm max-w-sm">
@@ -166,6 +174,7 @@ export default function JoinUs() {
                                                         width={24}
                                                         height={24}
                                                         className="w-6 h-6 transition-transform duration-300 ease-out group-hover:scale-110 group-hover:brightness-110 group-hover:saturate-125"
+                                                        draggable={false}
                                                     />
                                                 ) : (
                                                     <social.icon className="w-6 h-6 text-muted transition-transform duration-300 ease-out group-hover:scale-110 group-hover:text-brand" />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -73,6 +73,7 @@ export default function Navbar() {
                                         width={64}
                                         height={64}
                                         className="w-full h-full object-contain"
+                                        draggable={false}
                                     />
                                 </div>
                                 <div className={`transition-colors duration-300 ${logoColor}`}>


### PR DESCRIPTION
## Summary
- disable selecting text on homepage
- prevent images and icons from being dragged or selected

## Testing
- `npm run build` *(fails: Failed to fetch font `Source Sans 3` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cd128d1083239c9806f6250d5c7c