### PR TITLE
調整簡報位置與卡片互動效果

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -3,28 +3,15 @@
 import { useState, useEffect, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import Image from 'next/image';
-import event_img_1 from '@/images/events/1.png';
-import event_img_2 from '@/images/events/2.png';
-import event_img_3 from '@/images/events/3.png';
-import event_img_4 from '@/images/events/4.png';
-import event_img_5 from '@/images/events/5.png';
 import assemblyGif from '@/images/stickers/assembly.gif';
 
 
 export default function Events() {
     const [isVisible, setIsVisible] = useState(false);
-    const [currentImage, setCurrentImage] = useState(0);
+    const [activeIndex, setActiveIndex] = useState(null); // 手機版目前置中的卡片索引
     const ref = useRef(null);
+    const cardRefs = useRef([]); // 儲存各卡片的參考
     const { language } = useLanguage();
-
-    // 活動圖片 - 使用 public 目錄中的圖片
-    const eventImages = [
-        event_img_1,
-        event_img_2,
-        event_img_3,
-        event_img_4,
-        event_img_5
-    ];
 
     // 亮點內容
     // - 行動版卡片由下而上進場
@@ -85,76 +72,51 @@ export default function Events() {
         };
     }, []);
 
-    // Auto-carousel
+    // 手機版捲動偵測置中卡片
     useEffect(() => {
-        if (eventImages.length > 1) {
-            const interval = setInterval(() => {
-                setCurrentImage((prev) => (prev + 1) % eventImages.length);
-            }, 4000);
-            return () => clearInterval(interval);
-        }
-    }, [eventImages.length]);
+        const handleScroll = () => {
+            if (window.innerWidth >= 768) return; // 只在手機版執行
+            const middle = window.innerHeight / 2;
+            let target = null;
+            cardRefs.current.forEach((card, index) => {
+                const rect = card.getBoundingClientRect();
+                if (rect.top <= middle && rect.bottom >= middle) {
+                    target = index;
+                }
+            });
+            setActiveIndex(target);
+        };
+
+        handleScroll();
+        window.addEventListener('scroll', handleScroll);
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, []);
 
     return (
         <section id="events" className="py-20 md:py-32 px-4 md:px-6 bg-transparent" ref={ref}>
             <div className="max-w-7xl mx-auto">
                 <div className="grid lg:grid-cols-2 gap-12 md:gap-16 items-center">
 
-                    {/* Left: Images */}
+                    {/* Left: Slides */}
                     <div className={`relative transition-all duration-1000 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
-                        <div className="relative overflow-hidden rounded-2xl shadow-2xl bg-surface/30 backdrop-blur-lg border border-border h-64 md:h-80 lg:h-96 group">
-                            {/* 添加內陰影效果 */}
-                            <div className="absolute inset-0 rounded-2xl shadow-inner pointer-events-none z-10"></div>
-                            <div
-                                className="flex transition-transform duration-700 ease-in-out h-full"
-                                style={{ transform: `translateX(-${currentImage * 100}%)` }}
+                        <div className="relative w-full h-64 md:h-80 lg:h-96 border border-border rounded-2xl overflow-hidden shadow-2xl bg-surface/30 backdrop-blur-lg">
+                            {/* 內嵌簡報 */}
+                            <iframe
+                                src="https://www.slideshare.net/slideshow/embed_code/key/1QT8eizVmSnyWg?startSlide=1"
+                                className="w-full h-full"
+                                frameBorder="0"
+                                allowFullScreen
+                            ></iframe>
+                        </div>
+                        <div className="mt-3 text-center">
+                            <a
+                                href="https://www.slideshare.net/slideshow/demystifying-ai-from-core-concepts-to-practical-workflows-with-n8n-e67e/279081313"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="phone-liner-bold md:pc-liner-bold text-brand hover:underline"
                             >
-                                {eventImages.map((src, index) => (
-                                    <div key={index} className="w-full flex-shrink-0 h-full">
-                                        <div className="w-full h-full relative">
-                                            <Image
-                                                src={src}
-                                                alt={`Build with AI Event #${index + 1}`}
-                                                fill
-                                                sizes="100vw"
-                                                className="object-cover transition-transform duration-500 group-hover:scale-105"
-                                                draggable={false}
-                                                onError={(e) => {
-                                                    // 如果圖片加載失敗，隱藏 img 並顯示同父容器內的佔位符
-                                                    try {
-                                                        const img = e.target;
-                                                        img.style.display = 'none';
-                                                        const parent = img.closest('.w-full.h-full') || img.parentElement;
-                                                        const placeholder = parent?.querySelector('.placeholder');
-                                                        if (placeholder) placeholder.style.display = 'flex';
-                                                    } catch (err) {
-                                                        // noop
-                                                    }
-                                                }}
-                                            />
-                                            <div 
-                                                className="placeholder absolute inset-0 w-full h-full bg-gradient-to-br from-brand/70 to-purple-600/70 flex items-center justify-center"
-                                                style={{ display: 'none' }}
-                                            >
-                                                <span className="text-white text-xl font-semibold opacity-80">
-                                                    Build with AI Event #{index + 1}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-
-                            {/* Image indicators */}
-                            <div className="absolute bottom-6 left-1/2 transform -translate-x-1/2 flex space-x-3 z-10">
-                                {eventImages.map((_, index) => (
-                                    <button
-                                        key={index}
-                                        onClick={() => setCurrentImage(index)}
-                                        className={`w-3 h-3 rounded-full transition-all duration-300 shadow-lg ${currentImage === index ? 'bg-white scale-125' : 'bg-white/60 hover:bg-white/80'}`}
-                                    />
-                                ))}
-                            </div>
+                                Demystifying AI: From Core Concepts to Practical Workflows with n8n
+                            </a>
                         </div>
                     </div>
 
@@ -189,44 +151,24 @@ export default function Events() {
                         {/* Highlights */}
         
                         {/* 行動版由下而上、桌面版由右至左進場 */}
-                        <div className="space-y-6">
-                            {highlights.map((highlight, index) => (
-                                <div
-                                    key={index}
-                                    className={`p-6 md:p-8 bg-surface/50 backdrop-blur-lg border border-border rounded-xl shadow-sm transition-all duration-500 ${isVisible ? 'opacity-100 translate-y-0 md:translate-x-0' : 'opacity-0 translate-y-6 md:translate-x-6'} hover:bg-surface/80 hover:border-brand hover:shadow-lg hover:scale-[1.02]`}
-                                    style={{ transitionDelay: `${0.5 + index * 0.15}s` }}
-                                >
-                                    <h3 className="phone-liner-bold md:pc-liner-bold text-heading mb-2">
-                                        {highlight.title}
-                                    </h3>
-                                    <p className="phone-liner md:pc-liner text-muted leading-relaxed">
-                                        {highlight.description}
-                                    </p>
-                                </div>
-                            ))}
-                        </div>
+                          <div className="space-y-6">
+                              {highlights.map((highlight, index) => (
+                                  <div
+                                      key={index}
+                                      ref={(el) => (cardRefs.current[index] = el)} // 紀錄卡片 DOM 以供偵測
+                                      className={`p-6 md:p-8 bg-surface/50 backdrop-blur-lg border border-border rounded-xl shadow-sm transition-all duration-500 ${isVisible ? 'opacity-100 translate-y-0 md:translate-x-0' : 'opacity-0 translate-y-6 md:translate-x-6'} hover:bg-surface/80 hover:border-brand hover:shadow-lg hover:scale-[1.02] ${activeIndex === index ? 'border-brand bg-brand/10' : ''}`}
+                                      style={{ transitionDelay: `${0.5 + index * 0.15}s` }}
+                                  >
+                                      <h3 className="phone-liner-bold md:pc-liner-bold text-heading mb-2">
+                                          {highlight.title}
+                                      </h3>
+                                      <p className="phone-liner md:pc-liner text-muted leading-relaxed">
+                                          {highlight.description}
+                                      </p>
+                                  </div>
+                              ))}
+                          </div>
 
-                        {/* Slides */}
-                        <div className="mt-12">
-                            <div className="relative w-full h-64 md:h-96 border border-border rounded-xl overflow-hidden shadow-md">
-                                <iframe
-                                    src="https://www.slideshare.net/slideshow/embed_code/key/1QT8eizVmSnyWg?startSlide=1"
-                                    className="w-full h-full"
-                                    frameBorder="0"
-                                    allowFullScreen
-                                ></iframe>
-                            </div>
-                            <div className="mt-3 text-center">
-                                <a
-                                    href="https://www.slideshare.net/slideshow/demystifying-ai-from-core-concepts-to-practical-workflows-with-n8n-e67e/279081313"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="phone-liner-bold md:pc-liner-bold text-brand hover:underline"
-                                >
-                                    Demystifying AI: From Core Concepts to Practical Workflows with n8n
-                                </a>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- 將簡報移至左側欄位並提供外部連結
- 卡片新增 hover 與手機版置中偵測標註

## Testing
- ⚠️ `npm run build`（無法下載 Google Fonts）

------
https://chatgpt.com/codex/tasks/task_e_68b83e4988b88323b1458c73628e0692