### PR TITLE
改進 JOINUS 光球背景並更新文案

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -428,16 +428,17 @@ html {
 }
 
 /* 極光流動背景 */
-/* JOINUS 區塊藍色光暈背景 */
+/* JOINUS 區塊藍色光球背景 */
 .joinus-glow {
-  width: 120%;
-  height: 120%;
+  width: 60vmin;
+  height: 60vmin;
   border-radius: 9999px;
-  background: radial-gradient(circle, rgba(66, 133, 244, 0.35), transparent 60%);
+  background: radial-gradient(circle, rgba(66, 133, 244, 0.35), transparent 70%);
+  filter: blur(80px); /* 模糊處理讓邊緣柔和 */
   z-index: -1;
 }
 .dark .joinus-glow {
-  background: radial-gradient(circle, rgba(66, 133, 244, 0.25), transparent 60%);
+  background: radial-gradient(circle, rgba(66, 133, 244, 0.25), transparent 70%);
 }
 
 /* 滑鼠跟隨聚光燈 */

--- a/src/components/JoinUs.jsx
+++ b/src/components/JoinUs.jsx
@@ -178,7 +178,8 @@ export default function JoinUs() {
                             className="w-7 h-7 md:w-8 md:h-8"
                             draggable={false}
                         />
-                        <span>{language === 'zh' ? '立即加入 LINE 社群' : 'Join our LINE group now'}</span>
+                        {/* 按鈕文字：加入 LINE 群組 */}
+                        <span>{language === 'zh' ? '立即加入 LINE 群組' : 'Join our LINE group now'}</span>
                         <ArrowRightIcon className="w-6 h-6 md:w-7 md:h-7" />
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- 將 JOINUS 區塊的藍色背景改為中央藍色光球並柔化邊緣
- 將 CTA 按鈕文案改為「立即加入 LINE 群組」

## Testing
- `npm test` (fail: Missing script "test")
- `npm run build` (fail: Failed to fetch font `Source Sans 3`)


------
https://chatgpt.com/codex/tasks/task_e_68b894b8373c83238b9339b564345c08