### PR TITLE
更新行事曆標題為社群行事曆

### DIFF
--- a/COMPONENTS_SUMMARY.md
+++ b/COMPONENTS_SUMMARY.md
@@ -49,7 +49,7 @@
   - Mockup 設計預覽
 
 ### 6. **Calendar** (`/src/components/Calendar.jsx`)
-- **功能**: 官方行事曆展示
+- **功能**: 官方社群行事曆展示
 - **特色**:
   - Google Calendar 嵌入式視圖
   - 依主題切換背景顏色

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-// 行事曆區塊，嵌入 Google Calendar，支援亮暗色主題與 RWD
+// 社群行事曆區塊，嵌入 Google Calendar，支援亮暗色主題與 RWD
 import { useState, useEffect, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useTheme } from '@/hooks/useTheme';
@@ -29,7 +29,7 @@ export default function Calendar() {
         <section id="calendar" className="bg-surface-muted py-20 md:py-32 px-4 md:px-6" ref={ref}>
             <div className={`max-w-5xl mx-auto transition-opacity duration-1000 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
                 <h2 className="phone-h1 md:pc-h2 text-heading text-center mb-8">
-                    {language === 'zh' ? '行事曆' : 'Calendar'}
+                    {language === 'zh' ? '社群行事曆' : 'Calendar'}
                 </h2>
                 <div className="rounded-xl overflow-hidden shadow-lg relative">
                     <iframe


### PR DESCRIPTION
## Summary
- 調整 Calendar 元件顯示文字為「社群行事曆」，並更新相關註解
- 更新元件文件，說明使用官方社群行事曆

## Testing
- ⚠️ `npm test`（無測試腳本）
- ⚠️ `npm run build`（因無法取得字型而失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b8a00a89bc8323a124d92abc6de7ba