### PR TITLE
加快 Hero 按鈕主題切換速度

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -20,11 +20,16 @@ import sliderGif from '@/images/stickers/slider.gif';
 
 export default function Hero() {
     const [isLoaded, setIsLoaded] = useState(false);
+    // 用於控制按鈕切換延遲的狀態
+    const [buttonDelay, setButtonDelay] = useState('0.9s');
     const { language } = useLanguage();
     const { theme } = useTheme();
 
     useEffect(() => {
         setIsLoaded(true);
+        // 一秒後移除延遲，避免切換主題時速度過慢
+        const timer = setTimeout(() => setButtonDelay('0s'), 1000);
+        return () => clearTimeout(timer);
     }, []);
 
     const scrollToNext = () => {
@@ -65,11 +70,16 @@ export default function Hero() {
 
 export default function Hero() {
     const [isLoaded, setIsLoaded] = useState(false);
+    // 用於控制按鈕切換延遲的狀態
+    const [buttonDelay, setButtonDelay] = useState('0.9s');
     const { language } = useLanguage();
     const { theme } = useTheme();
 
     useEffect(() => {
         setIsLoaded(true);
+        // 一秒後移除延遲，避免切換主題時速度過慢
+        const timer = setTimeout(() => setButtonDelay('0s'), 1000);
+        return () => clearTimeout(timer);
     }, []);
 
     const scrollToNext = () => {
@@ -132,13 +142,13 @@ export default function Hero() {
 
                 <button
                     onClick={scrollToNext}
-                    className={`px-6 py-4 md:px-12 md:py-6 rounded-xl phone-liner-bold md:pc-liner-bold transition-all duration-300 flex items-center space-x-3 md:space-x-5 mx-auto group ${isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+                    className={`px-6 py-4 md:px-12 md:py-6 rounded-xl phone-liner-bold md:pc-liner-bold transition-all duration-200 flex items-center space-x-3 md:space-x-5 mx-auto group ${isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
                         } w-full max-w-xs md:max-w-sm lg:w-auto lg:max-w-none justify-center transform hover:scale-105 shadow-xl 
                         ${theme === 'light'
                             ? 'bg-white/70 backdrop-blur-sm border border-slate-300/80 hover:shadow-lg'
                             : 'bg-brand hover:bg-brand-accent text-white hover:shadow-lg hover:shadow-brand/40'
                         }`}
-                    style={{ transitionDelay: '0.9s' }}
+                    style={{ transitionDelay: buttonDelay }}
                 >
                     <Image
                         src={sliderGif}


### PR DESCRIPTION
## Summary
- 移除 Hero 按鈕在主題切換時的延遲，並縮短轉場時間
- 新增狀態控制按鈕延遲，一秒後移除以加快切換速度

## Testing
- `npm test`（缺少 test 指令）
- `npm run build`（無法下載字型，編譯失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b8a37f08c48323aeb0791136c13adc