### PR TITLE
feat: 手機卡片邊框淡化與螢光筆標註

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,10 @@
   --surface: #ffffff;
   --surface-muted: #f8f9fa;
   --border: #e8eaed;
+  /* 手機未顯示卡片邊框色 */
+  --border-faded: #d1d5db;
+  /* 螢光筆標註顏色 */
+  --highlight-color: #fef08a;
   --muted: #5f6368;
   --heading: #202124;
   --brand: #4285f4;
@@ -31,6 +35,10 @@
   --surface: #1e1e1e;
   --surface-muted: #121212;
   --border: #3c4043;
+  /* 手機未顯示卡片邊框色 */
+  --border-faded: #4b5563;
+  /* 螢光筆標註顏色 */
+  --highlight-color: #fef08a;
   --muted: #9aa0a6;
   --heading: #8ab4f8;
   --brand: #8ab4f8;
@@ -495,4 +503,17 @@ img,
 svg {
   -webkit-user-drag: none;
   user-select: none;
+}
+
+/* 螢光筆文字標註效果 */
+.highlight-text {
+  background: linear-gradient(90deg, var(--highlight-color), var(--highlight-color)) 0 0 / 0% 100% no-repeat;
+  transition: background-size 0.3s steps(12);
+}
+
+/* 滑鼠或手機標註時啟動螢光筆動畫 */
+.group:hover .highlight-text,
+.group:focus .highlight-text,
+.highlight-active .highlight-text {
+  background-size: 100% 100%;
 }

--- a/src/components/Vision.jsx
+++ b/src/components/Vision.jsx
@@ -70,7 +70,8 @@ export default function Vision() {
         if (!card) return;
         card.style.transition = 'transform 0.4s ease-out';
         card.style.transform = 'perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)';
-        card.style.borderColor = 'var(--color-border)';
+        // 邊框回復為預設顏色
+        card.style.borderColor = 'var(--border)';
         card.style.boxShadow = 'none';
         const sheen = card.querySelector('.sheen');
         if (sheen) sheen.style.opacity = '0';
@@ -124,8 +125,11 @@ export default function Vision() {
                 if (!card) return;
                 const isActive = card === closestCard;
                 card.style.transform = `scale(${isActive ? 1 : 0.9})`;
-                card.style.borderColor = isActive ? card.dataset.color : 'var(--color-border)';
+                // 非焦點卡片邊框使用淡化色
+                card.style.borderColor = isActive ? card.dataset.color : 'var(--border-faded)';
                 card.style.boxShadow = isActive ? `0 0 20px ${card.dataset.color}66` : 'none';
+                // 手機板高亮顯示目前卡片的文字
+                card.classList.toggle('highlight-active', isActive);
                 const outlineIcon = card.querySelector('.icon-outline');
                 const solidIcon = card.querySelector('.icon-solid');
                 if (outlineIcon && solidIcon) {
@@ -238,7 +242,7 @@ export default function Vision() {
                                 <h3 className="phone-h3 md:pc-h2 text-heading mb-4 md:mb-6 text-center">
                                     {card.title}
                                 </h3>
-                                <p className="phone-liner md:pc-liner text-muted leading-relaxed text-center">
+                                <p className="phone-liner md:pc-liner text-muted leading-relaxed text-center highlight-text">
                                     {card.description}
                                 </p>
                             </div>


### PR DESCRIPTION
## Summary
- 手機版非焦點卡片邊框改為淺/深灰淡化
- hover 與手機焦點時顯示螢光筆文字標註動畫

## Testing
- `npm test` (missing script)
- `npm run build` (Failed to fetch font `Source Sans 3` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68b8a6a7a3d883238ebfb975c67ecb99