### PR TITLE
調整淺色模式卡片淡化效果

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -422,7 +422,8 @@ export default function Projects() {
                                 ref={el => cardInnerRefs.current[index] = el}
                                 onMouseMove={e => handleMouseMove(e, index)}
                                 onMouseLeave={() => handleMouseLeave(index)}
-                                className={`relative rounded-2xl border p-6 flex flex-col h-full shadow-lg transition-transform duration-75 transform-gpu will-change-transform overflow-hidden ${isMobile ? (activeCard === index ? 'bg-surface border-border shadow-[0_0_25px_rgba(59,130,246,0.5)]' : 'bg-surface-muted border-gray-300 dark:bg-gray-800 dark:border-gray-700') : 'bg-surface border-border hover:shadow-[0_0_25px_rgba(59,130,246,0.5)]'}`}
+                                // 手機非焦點卡片於淺色模式下以淺灰底淡化
+                                className={`relative rounded-2xl border p-6 flex flex-col h-full shadow-lg transition-transform duration-75 transform-gpu will-change-transform overflow-hidden ${isMobile ? (activeCard === index ? 'bg-surface border-border shadow-[0_0_25px_rgba(59,130,246,0.5)]' : 'bg-gray-200 border-gray-300 dark:bg-gray-800 dark:border-gray-700') : 'bg-surface border-border hover:shadow-[0_0_25px_rgba(59,130,246,0.5)]'}`}
                             >
                                 <span className={`pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-cyan-500 via-blue-500 to-purple-600 blur-md transition-opacity duration-300 ${isMobile ? (activeCard === index ? 'opacity-50' : 'opacity-0') : 'opacity-0 group-hover:opacity-50'}`}></span>
                                 {/* 實際內容 */}
@@ -432,7 +433,8 @@ export default function Projects() {
                                         {(() => {
                                             const statusClass =
                                                 isMobile && activeCard !== index
-                                                    ? 'bg-surface-muted text-gray-400 border border-gray-300 dark:bg-gray-800 dark:text-gray-600 dark:border-gray-700'
+                                                    // 非焦點卡片的狀態標籤在淺色模式下改為淺灰背景
+                                                    ? 'bg-gray-200 text-gray-400 border border-gray-300 dark:bg-gray-800 dark:text-gray-600 dark:border-gray-700'
                                                     : feature.status === '已上線' || feature.status === '已完成' || feature.status === 'Released' || feature.status === 'Completed'
                                                         ? 'bg-green-500 text-white dark:bg-green-600'
                                                         : feature.status === '進行中' || feature.status === 'In Progress'
@@ -450,7 +452,8 @@ export default function Projects() {
                                         {feature.tags.map(tag => (
                                             <span
                                                 key={tag}
-                                                className={`px-2 py-1 text-xs rounded ${isMobile && activeCard !== index ? 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600' : 'bg-brand/10 text-brand'}`}
+                                                // 淺色模式淡化用淺灰色標籤底色
+                                                className={`px-2 py-1 text-xs rounded ${isMobile && activeCard !== index ? 'bg-gray-200 text-gray-400 dark:bg-gray-800 dark:text-gray-600' : 'bg-brand/10 text-brand'}`}
                                             >
                                                 {tag}
                                             </span>


### PR DESCRIPTION
## Summary
- 調整專案卡片在淺色模式下的淡化背景為淺灰色
- 同步更新狀態標籤與標籤底色以保持一致

## Testing
- `npm test` *(缺少測試腳本)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a8c751948323b6552b4857417fb5