### PR TITLE
feat: constrain joinus heading line break

### DIFF
--- a/src/components/JoinUs.jsx
+++ b/src/components/JoinUs.jsx
@@ -155,9 +155,17 @@ export default function JoinUs() {
                 <div className="relative z-10">
                     <h2
                         className={`rainbow-text phone-h1 md:pc-h1 mb-6 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
+                        style={{ wordBreak: 'keep-all' }}
                     >
                         {/* 更新標題內容，改為「用程式碼定義彰師未來」 */}
-                        {language === 'zh' ? '用程式碼定義彰師未來' : 'Define NCUE\'s future with code'}
+                        {language === 'zh'
+                            ? (
+                                <>
+                                    {/* 使用 wbr 控制換行位置 */}
+                                    用程式碼<wbr />定義彰師未來
+                                </>
+                            )
+                            : "Define NCUE's future with code"}
                     </h2>
                     <p className={`phone-liner md:pc-h3 text-muted max-w-3xl mx-auto mb-10 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`} style={{ transitionDelay: '0.2s' }}>
                         {language === 'zh'


### PR DESCRIPTION
## Summary
- 限制 JoinUs 標題僅在「用程式碼」後方換行

## Testing
- `npm test` (Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b8acb43ae48323a8d64a70ed0f7527