### PR TITLE
調整螢光筆與卡片配色

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,7 @@
   --muted: #5f6368;
   --heading: #202124;
   --brand: #4285f4;
-  --brand-accent: #1a73e8;
+  --brand-accent: #4285f4; /* Google 藍 */
   --accent: #ea4335;
   --warn: #fbbc04;
   --text-on-brand: #ffffff;
@@ -33,8 +33,8 @@
   --border: #3c4043;
   --muted: #9aa0a6;
   --heading: #8ab4f8;
-  --brand: #8ab4f8;
-  --brand-accent: #aecbfa;
+  --brand: #4285f4; /* Google 藍 */
+  --brand-accent: #4285f4; /* Google 藍 */
   --accent: #f28b82;
   --warn: #fdd663;
   --text-on-brand: #202124;
@@ -511,8 +511,8 @@ svg {
   transform: translateY(-50%);
   width: 0%;
   height: 0.8em;
-  background: var(--brand-accent);
-  opacity: 0.4;
+  background: var(--brand-accent); /* 螢光筆使用 Google 藍 */
+  opacity: 0.4; /* 保留適度透明度 */
   border-radius: 0.25em;
   z-index: -1;
   transition: width 0.4s ease;

--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -282,14 +282,14 @@ export default function Events() {
                                 <div
                                     key={index}
                                     ref={(el) => (cardRefs.current[index] = el)}
-                                    className={`p-6 md:p-8 bg-surface/50 backdrop-blur-lg border border-border rounded-xl shadow-sm transition-all duration-300 group ${isVisible ? 'opacity-100 translate-y-0 md:translate-x-0' : 'opacity-0 translate-y-6 md:translate-x-6'} md:hover:bg-brand/10 md:hover:border-brand md:hover:shadow-[0_0_20px_var(--brand)] md:hover:-translate-y-1 md:hover:scale-[1.02] md:cursor-pointer`}
+                                    className={`p-6 md:p-8 bg-surface/50 backdrop-blur-lg border border-brand rounded-xl shadow-sm transition-all duration-300 group ${isVisible ? 'opacity-100 translate-y-0 md:translate-x-0' : 'opacity-0 translate-y-6 md:translate-x-6'} md:hover:bg-brand/10 md:hover:border-brand md:hover:shadow-[0_0_20px_var(--brand)] md:hover:-translate-y-1 md:hover:scale-[1.02] md:cursor-pointer`}
                                     style={{ transitionDelay: isVisible ? '0s' : `${0.5 + index * 0.15}s` }}
                                 >
                                     <h3 className="phone-liner-bold md:pc-liner-bold text-heading mb-2">
                                         <span className="highlight-line">{highlight.title}</span>
                                     </h3>
                                     <p className="phone-liner md:pc-liner text-muted leading-relaxed">
-                                        <span className="highlight-line">{highlight.description}</span>
+                                        {highlight.description}
                                     </p>
                                 </div>
                             ))}

--- a/src/components/Vision.jsx
+++ b/src/components/Vision.jsx
@@ -152,21 +152,21 @@ export default function Vision() {
                 description: '我們捕捉靈感的火花，化為程式的語句，讓校園日常因它而閃耀新的光彩。我們敢於嘗試，親手創造，讓系統真正服務於師生的需求。在這裡，AI 與科技不再是遙遠的夢想，而是你我都能掌握的力量。',
                 outline: CodeBracketSquareIconOutline,
                 solid: CodeBracketSquareIconSolid,
-                color: '#4285F4' // Google 藍
+                color: '#EA4335' // Google 紅
             },
             {
                 title: '社群同心，淬鍊前行',
                 description: '我們追求的不僅是技術的深度，更是思想交鋒激盪出的集體智慧。從 AI 應用到網頁開發，這裡是一個為熱愛技術的人而生的舞台。在這裡，你不是旁觀者，而是共創者；彼此啟發、互相成就，一同定義卓越，淬鍊出屬於我們的成長。',
                 outline: AcademicCapIconOutline,
                 solid: AcademicCapIconSolid,
-                color: '#EA4335' // Google 紅
+                color: '#FBBC05' // Google 黃
             },
             {
                 title: '放眼全球，開創新猷',
                 description: '你的才華，值得被世界看見。我們為你搭起橋樑，連結 Google 與全球開發者的廣闊生態。無論你尋找的是一位指引的導師、一群志同道合的戰友，或是一個能證明自己的國際舞台，這裡，都是夢想啟程的起點。',
                 outline: GlobeAltIconOutline,
                 solid: GlobeAltIconSolid,
-                color: '#FBBC05' // Google 黃
+                color: '#34A853' // Google 綠
             }
         ]
         : [
@@ -175,21 +175,21 @@ export default function Vision() {
                 description: 'We capture sparks of inspiration and shape them into lines of code, illuminating everyday campus life with new brilliance. We dare to try and create with our own hands, building systems that truly serve the needs of students and faculty. Here, AI and technology are no longer distant dreams, but real forces you and I can grasp to drive change.',
                 outline: CodeBracketSquareIconOutline,
                 solid: CodeBracketSquareIconSolid,
-                color: '#4285F4' // Google 藍
+                color: '#EA4335' // Google 紅
             },
             {
                 title: 'United in Community, Forged in Growth',
                 description: 'What we seek is not only the depth of technology, but also the collective wisdom born from the clash of ideas. From AI applications to web development, this is a stage built for those who love to create with technology. Here, you are not a bystander, but a co-creator; through inspiration and collaboration, we define excellence together and forge our shared growth.',
                 outline: AcademicCapIconOutline,
                 solid: AcademicCapIconSolid,
-                color: '#EA4335' // Google 紅
+                color: '#FBBC05' // Google 黃
             },
             {
                 title: 'Reaching the Globe, Creating New Roads',
                 description: 'Your talent deserves to be seen by the world. We build bridges that connect you to Google and the global community of developers. Whether you seek the guidance of a mentor, a team of like-minded partners, or an international stage to prove yourself—this is where your journey begins.',
                 outline: GlobeAltIconOutline,
                 solid: GlobeAltIconSolid,
-                color: '#FBBC05' // Google 黃
+                color: '#34A853' // Google 綠
             }
         ];
 


### PR DESCRIPTION
## 摘要
- 僅保留活動亮點標題的螢光筆效果並移除內文標註
- 讓活動亮點卡片邊框使用 Google 藍
- 願景區塊三張卡片依序改為 Google 紅、黃、綠

## 測試
- `npm test`（缺少 script）
- `npm run build`（網路連線問題導致失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b8ae4f36088323b83300faddaaffd0