### PR TITLE
feat: 調整 events 邊框與深色螢光筆顏色

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -546,6 +546,10 @@ svg {
   z-index: -1;
   transition: width 0.4s ease;
 }
+[data-theme="dark"] .highlight-line::before {
+  background: #8ab4f8; /* 深色模式使用較亮的藍色 */
+  opacity: 0.6; /* 提高透明度以增加對比 */
+}
 .group:hover .highlight-line::before,
 .card-active .highlight-line::before {
   width: 100%;

--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -132,14 +132,15 @@ export default function Events() {
             cardRefs.current.forEach((card) => {
                 if (!card) return;
                 const isActive = card === closestCard;
-                const borderBase = getComputedStyle(document.documentElement).getPropertyValue('--border');
+                const brandBase = getComputedStyle(document.documentElement).getPropertyValue('--brand');
                 // 以平移與光暈呈現專業的過渡效果，避免因放大造成爆版
                 card.style.transform = `translateY(${isActive ? '-4px' : '0'}) scale(${isActive ? '1.02' : '1'})`;
                 card.style.boxShadow = isActive ? '0 0 20px var(--brand)' : '';
                 card.classList.toggle('bg-brand/10', isActive);
                 card.classList.toggle('border-brand', isActive);
                 card.classList.toggle('card-active', isActive);
-                card.style.borderColor = isActive ? '' : hexToRGBA(borderBase, 0.4);
+                // 非活躍卡片使用透明藍色邊框
+                card.style.borderColor = isActive ? '' : hexToRGBA(brandBase, 0.4);
 
                 // 非活躍卡片文字淡化為灰色，根據主題使用對應灰色
                 const title = card.querySelector('h3');
@@ -170,7 +171,7 @@ export default function Events() {
                     {/* Left: 圖片與簡報 */}
                     <div className={`space-y-8 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
                         {/* 圖片輪播 */}
-                        <div className="relative overflow-hidden rounded-2xl shadow-2xl bg-surface/30 backdrop-blur-lg border border-border h-64 md:h-80 lg:h-96 group">
+                        <div className="relative overflow-hidden rounded-2xl shadow-2xl bg-surface/30 backdrop-blur-lg border border-brand h-64 md:h-80 lg:h-96 group">
                             {/* 添加內陰影效果 */}
                             <div className="absolute inset-0 rounded-2xl shadow-inner pointer-events-none z-10"></div>
                             <div
@@ -226,7 +227,7 @@ export default function Events() {
                         </div>
 
                         {/* 簡報內嵌 */}
-                        <div className="relative w-full h-64 md:h-96 border border-border rounded-xl overflow-hidden shadow-md">
+                        <div className="relative w-full h-64 md:h-96 border border-brand rounded-xl overflow-hidden shadow-md">
                             <iframe
                                 src="https://www.slideshare.net/slideshow/embed_code/key/1QT8eizVmSnyWg?startSlide=1"
                                 className="w-full h-full"


### PR DESCRIPTION
## Summary
- 使用 Google 藍更新 events 區塊邊框
- 深色模式下將螢光筆改為更亮的藍色，提升對比度

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch `Source Sans 3` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b082c4fc8323963973303bda42fe