### PR TITLE
fix: 移除主題切換按鈕選取框

### DIFF
--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -17,7 +17,8 @@ export default function ThemeSwitcher({ colorClass }) {
     return (
         <button
             onClick={toggleTheme}
-            className={`p-2 rounded-full transition-all duration-300 hover:scale-110 hover:bg-surface-muted/30 hover:shadow-md ${buttonColorClass}`}
+            // 移除點擊後的按鈕選取框
+            className={`p-2 rounded-full transition-all duration-300 hover:scale-110 hover:bg-surface-muted/30 hover:shadow-md focus:outline-none focus:ring-0 ${buttonColorClass}`}
             aria-label="Toggle theme"
         >
             {theme === 'light' ? (


### PR DESCRIPTION
## 摘要
- 移除主題切換按鈕點擊後的選取框

## 測試
- `npm run build`（失敗：無法下載 Source Sans 3 字體）

------
https://chatgpt.com/codex/tasks/task_e_68b8b3cb9e088323bfc0a98dea8ef6f8