### PR TITLE
feat: 活動卡片懸浮使用 Google 藍色邊框

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -280,10 +280,11 @@ export default function Events() {
                         {/* 行動版由下而上、桌面版由右至左進場 */}
                         <div className="space-y-6">
                             {highlights.map((highlight, index) => (
+                                // 卡片懸浮時使用 Google 藍色邊框
                                 <div
                                     key={index}
                                     ref={(el) => (cardRefs.current[index] = el)}
-                                    className={`p-6 md:p-8 bg-surface/50 backdrop-blur-lg border border-brand rounded-xl shadow-sm transition-all duration-300 group ${isVisible ? 'opacity-100 translate-y-0 md:translate-x-0' : 'opacity-0 translate-y-6 md:translate-x-6'} md:hover:bg-brand/10 md:hover:border-brand md:hover:shadow-[0_0_20px_var(--brand)] md:hover:-translate-y-1 md:hover:scale-[1.02] md:cursor-pointer`}
+                                    className={`p-6 md:p-8 bg-surface/50 backdrop-blur-lg border border-border rounded-xl shadow-sm transition-all duration-300 group ${isVisible ? 'opacity-100 translate-y-0 md:translate-x-0' : 'opacity-0 translate-y-6 md:translate-x-6'} md:hover:bg-brand/10 hover:border-brand md:hover:shadow-[0_0_20px_var(--brand)] md:hover:-translate-y-1 md:hover:scale-[1.02] md:cursor-pointer`}
                                     style={{ transitionDelay: isVisible ? '0s' : `${0.5 + index * 0.15}s` }}
                                 >
                                     <h3 className="phone-liner-bold md:pc-liner-bold text-heading mb-2">


### PR DESCRIPTION
## Summary
- 調整活動區塊卡片邊框，懸浮時呈現 Google 藍色

## Testing
- `npm run build` *(失敗：無法下載字型 Source Sans 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b38242988323939356c40bd5ba84