### PR TITLE
修正專案區塊與活動標題在英文手機版的排版問題

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -527,34 +527,26 @@ svg {
 }
 
 /* 螢光筆掃過效果 */
+/* 多行螢光筆效果，支援文字換行 */
 .highlight-line {
   position: relative;
   display: inline;
   z-index: 0;
-}
-.highlight-line::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 0%;
-  height: 0.8em;
-  background: var(--brand-accent); /* 螢光筆使用 Google 藍 */
-  opacity: 0.4; /* 保留適度透明度 */
+  background-image: linear-gradient(transparent 60%, var(--brand-accent) 60%);
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  transition: background-size 0.4s ease;
+  box-decoration-break: clone;
   border-radius: 0.25em;
-  z-index: -1;
-  transition: width 0.4s ease;
 }
-[data-theme="dark"] .highlight-line::before {
-  background: #8ab4f8; /* 深色模式使用較亮的藍色 */
-  opacity: 0.6; /* 提高透明度以增加對比 */
+[data-theme="dark"] .highlight-line {
+  background-image: linear-gradient(transparent 60%, #8ab4f8 60%);
 }
-.group:hover .highlight-line::before,
-.card-active .highlight-line::before {
-  width: 100%;
+.group:hover .highlight-line,
+.card-active .highlight-line {
+  background-size: 100% 100%;
 }
-.group:hover p .highlight-line::before,
-.card-active p .highlight-line::before {
+.group:hover p .highlight-line,
+.card-active p .highlight-line {
   transition-delay: 0.15s;
 }

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -439,7 +439,8 @@ export default function Projects() {
                                 <span className={`pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-cyan-500 via-blue-500 to-purple-600 blur-md transition-opacity duration-300 ${isMobile ? (activeCard === index ? 'opacity-50' : 'opacity-0') : 'opacity-0 group-hover:opacity-50'}`}></span>
                                 {/* 實際內容 */}
                                 <div className="relative z-10 flex flex-col h-full">
-                                    <div className="flex justify-between items-start mb-4">
+                                    {/* 允許狀態膠囊在手機版換行避免爆版 */}
+                                    <div className="flex flex-wrap justify-between items-start gap-2 mb-4">
                                         <h3 className={`phone-h3 md:pc-h3 font-bold leading-tight ${isMobile && activeCard !== index ? 'text-gray-400 dark:text-gray-500' : 'text-heading'}`}>{feature.title}</h3>
                                         {(() => {
                                             // 依狀態取得對應色碼
@@ -454,7 +455,8 @@ export default function Projects() {
                                                 const animClass = isActive
                                                     ? (scrollDirection === 'down' ? 'tag-fill-down' : 'tag-fill-up')
                                                     : '';
-                                                const baseClass = 'px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border';
+                                                // 基礎樣式，禁止縮小避免文字被壓縮
+                                                const baseClass = 'px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap border shrink-0';
                                                 return isActive ? (
                                                     <span
                                                         className={`${baseClass} status-pill text-white ${animClass}`}


### PR DESCRIPTION
## Summary
- 調整 Projects 狀態膠囊容器與樣式，避免英文在手機版爆版
- 重寫 highlight-line 樣式，支援多行並正確顯示螢光筆效果

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8bdb7ae308323961b87d5547b2c3a